### PR TITLE
Fix submitReview crash when session reaches review without voting

### DIFF
--- a/src/engine/orchestrator.ts
+++ b/src/engine/orchestrator.ts
@@ -193,6 +193,11 @@ export class Orchestrator {
       updates.deliberationRound = (session.deliberationRound ?? 0) + 1;
     }
 
+    // Auto-create a placeholder decision when entering review without one
+    if (newPhase === 'review' && !this.store.getDecision(sessionId)) {
+      this.createDecision(sessionId, 'escalated', 'Manually advanced to review (no vote tally).');
+    }
+
     this.store.updateSession(sessionId, updates);
     this.emit({ type: 'session:phase_changed', sessionId, phase: newPhase });
   }


### PR DESCRIPTION
## Summary
- Auto-create a placeholder `Decision` (outcome: `escalated`) when a session enters the `review` phase without one (e.g. via manual phase transitions)
- Existing decisions from the voting engine are preserved and not overwritten
- Adds 2 new tests (41 total, all passing)

## Test plan
- [x] Unit test: placeholder decision created on manual transition to review
- [x] Unit test: existing voting decision not overwritten
- [x] Integration test: full manual flow (create → discussion → voting → review → approve → decided)
- [x] All 41 tests pass

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)