### PR TITLE
Fix SessionView real-time updates via WebSocket

### DIFF
--- a/src/web/app.tsx
+++ b/src/web/app.tsx
@@ -19,6 +19,7 @@ function App() {
   const [agents, setAgents] = useState<AgentStatusType[]>([]);
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
+  const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
 
   // Fetch initial data
   const fetchSessions = useCallback(async () => {
@@ -75,9 +76,17 @@ function App() {
             setSessions((prev) =>
               prev.map((s) => s.id === event.sessionId ? { ...s, phase: event.phase as Session['phase'] } : s),
             );
+            setSessionRefreshKey((k) => k + 1);
+            break;
+          case 'message:new':
+            setSessionRefreshKey((k) => k + 1);
+            break;
+          case 'vote:cast':
+            setSessionRefreshKey((k) => k + 1);
             break;
           case 'decision:pending_review':
             setDecisions((prev) => [event.decision, ...prev]);
+            setSessionRefreshKey((k) => k + 1);
             break;
           case 'event:received':
             setEvents((prev) => [event.event, ...prev].slice(0, 50));
@@ -178,6 +187,7 @@ function App() {
         {view === 'sessions' && selectedSessionId && (
           <SessionView
             sessionId={selectedSessionId}
+            refreshKey={sessionRefreshKey}
             onBack={() => setSelectedSessionId(null)}
           />
         )}

--- a/src/web/components/SessionView.tsx
+++ b/src/web/components/SessionView.tsx
@@ -11,6 +11,7 @@ interface SessionData {
 
 interface Props {
   sessionId: string;
+  refreshKey?: number;
   onBack: () => void;
 }
 
@@ -24,7 +25,7 @@ const phaseColors: Record<string, string> = {
   closed: 'var(--text-dim)',
 };
 
-export function SessionView({ sessionId, onBack }: Props) {
+export function SessionView({ sessionId, refreshKey, onBack }: Props) {
   const [data, setData] = useState<SessionData | null>(null);
 
   useEffect(() => {
@@ -33,9 +34,7 @@ export function SessionView({ sessionId, onBack }: Props) {
       if (res.ok) setData(await res.json());
     };
     load();
-    const interval = setInterval(load, 3000);
-    return () => clearInterval(interval);
-  }, [sessionId]);
+  }, [sessionId, refreshKey]);
 
   if (!data) {
     return <div style={{ color: 'var(--text-dim)', padding: 40 }}>Loading...</div>;


### PR DESCRIPTION
## Summary
- `SessionView` now reacts to WebSocket events instead of relying on 3s polling
- App tracks a `refreshKey` counter that increments on `session:phase_changed`, `message:new`, `vote:cast`, and `decision:pending_review` events
- `SessionView` re-fetches immediately when `refreshKey` changes
- Removed the `setInterval` polling in favor of event-driven updates

## Test plan
- [x] All 41 unit tests pass
- [x] Type-check clean (`tsc --noEmit`)
- [ ] Manual: open session detail view, advance phase via API, verify badge updates immediately

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)