### PR TITLE
Add AgentSdkSpawner for production agent launching

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.34",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "better-sqlite3": "^11.7.0",
     "drizzle-orm": "^0.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.34
+        version: 0.2.34(zod@3.25.76)
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@3.25.76)
@@ -77,6 +80,12 @@ importers:
         version: 2.1.9(@types/node@22.19.9)
 
 packages:
+
+  '@anthropic-ai/claude-agent-sdk@0.2.34':
+    resolution: {integrity: sha512-QLHd3Nt7bGU7/YH71fXFaztM9fNxGGruzTMrTYJkbm5gYJl5ZyU2zGyoE5VpWC0e1QU0yYdNdBVgqSYDcJGufg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -961,6 +970,99 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2611,6 +2713,19 @@ packages:
 
 snapshots:
 
+  '@anthropic-ai/claude-agent-sdk@0.2.34(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3172,6 +3287,65 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/engine/spawner.ts
+++ b/src/engine/spawner.ts
@@ -1,4 +1,5 @@
-import type { AgentSpawner, SpawnTask, SpawnerConfig } from '../shared/types.js';
+import type { AgentSpawner, AgentConfig, AgentLifecycleEvent, SpawnTask, SpawnerConfig } from '../shared/types.js';
+import type { AgentRegistry } from './agent-registry.js';
 
 /**
  * LogWebhookSpawner - Development/testing spawner.
@@ -34,31 +35,261 @@ export class LogWebhookSpawner implements AgentSpawner {
 
 /**
  * AgentSdkSpawner - Production spawner using Claude Agent SDK.
- * Placeholder implementation; real integration requires @anthropic-ai/claude-agent-sdk.
+ * Uses @anthropic-ai/claude-agent-sdk query() to launch autonomous agents
+ * that connect back to Council via MCP HTTP transport.
  */
+
+interface AgentSdkSpawnerOptions {
+  registry: AgentRegistry;
+  defaultModel?: string;
+  maxTurns?: number;
+  timeoutMs?: number;
+  onLifecycleEvent?: (event: AgentLifecycleEvent) => void;
+}
+
 export class AgentSdkSpawner implements AgentSpawner {
-  async spawn(task: SpawnTask): Promise<void> {
-    // TODO: Integrate with @anthropic-ai/claude-agent-sdk when available
-    console.log(`[SPAWN:SDK] Would spawn agent ${task.agentConfig.id} via Agent SDK`);
-    console.log(`[SPAWN:SDK] Model: ${task.agentConfig.model ?? 'default'}`);
-    console.log(`[SPAWN:SDK] Session: ${task.sessionId}`);
-    throw new Error(
-      'AgentSdkSpawner is not yet implemented. Install @anthropic-ai/claude-agent-sdk and implement the spawn method.',
-    );
+  private registry: AgentRegistry;
+  private defaultModel: string;
+  private maxTurns: number;
+  private timeoutMs: number;
+  private onLifecycleEvent?: (event: AgentLifecycleEvent) => void;
+  private sdkAvailable: boolean | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private queryFn: ((...args: any[]) => AsyncIterable<any>) | null = null;
+
+  constructor(opts: AgentSdkSpawnerOptions) {
+    this.registry = opts.registry;
+    this.defaultModel = opts.defaultModel ?? 'claude-sonnet-4-5-20250929';
+    this.maxTurns = opts.maxTurns ?? 100;
+    this.timeoutMs = opts.timeoutMs ?? 300_000; // 5 minutes
+    this.onLifecycleEvent = opts.onLifecycleEvent;
   }
+
+  private async ensureSdk(): Promise<boolean> {
+    if (this.sdkAvailable !== null) return this.sdkAvailable;
+
+    try {
+      const sdk = await import('@anthropic-ai/claude-agent-sdk');
+      this.queryFn = sdk.query;
+      this.sdkAvailable = true;
+      return true;
+    } catch {
+      console.error(
+        '[SPAWN:SDK] @anthropic-ai/claude-agent-sdk is not installed. '
+        + 'Run: pnpm add @anthropic-ai/claude-agent-sdk',
+      );
+      this.sdkAvailable = false;
+      return false;
+    }
+  }
+
+  async spawn(task: SpawnTask): Promise<void> {
+    const available = await this.ensureSdk();
+    if (!available) {
+      console.warn(
+        `[SPAWN:SDK] Falling back to log-only mode for agent ${task.agentConfig.id}. `
+        + 'Install the SDK for production use.',
+      );
+      console.log(`[SPAWN:SDK:FALLBACK] Agent ${task.agentConfig.id} for session ${task.sessionId}`);
+      console.log(`[SPAWN:SDK:FALLBACK] MCP URL: ${task.councilMcpUrl}`);
+      console.log(`[SPAWN:SDK:FALLBACK] Token: ${task.agentToken}`);
+      return;
+    }
+
+    // Fire-and-forget: start the agent loop but don't await it
+    this.runAgentWithRetry(task).catch((err) => {
+      console.error(`[SPAWN:SDK] Agent ${task.agentConfig.id} crashed: ${(err as Error).message}`);
+    });
+  }
+
+  private async runAgentWithRetry(task: SpawnTask, maxRetries = 2): Promise<void> {
+    let attempt = 0;
+    while (attempt <= maxRetries) {
+      try {
+        await this.runAgent(task);
+        return;
+      } catch (err) {
+        attempt++;
+        const error = err as Error;
+
+        // Don't retry budget or max-turn errors
+        if (error.message.includes('max_turns') || error.message.includes('max_budget')) {
+          console.error(`[SPAWN:SDK] Non-retryable error for ${task.agentConfig.id}: ${error.message}`);
+          return;
+        }
+
+        if (attempt > maxRetries) {
+          console.error(`[SPAWN:SDK] Agent ${task.agentConfig.id} failed after ${maxRetries} retries: ${error.message}`);
+          return;
+        }
+
+        const backoffMs = 1000 * Math.pow(2, attempt - 1);
+        console.warn(`[SPAWN:SDK] Retry ${attempt}/${maxRetries} for ${task.agentConfig.id} in ${backoffMs}ms`);
+        await new Promise((r) => setTimeout(r, backoffMs));
+      }
+    }
+  }
+
+  private async runAgent(task: SpawnTask): Promise<void> {
+    const { agentConfig, sessionId, context, councilMcpUrl, agentToken } = task;
+
+    const systemPrompt = this.buildSystemPrompt(agentConfig, sessionId, agentToken);
+    const prompt = this.buildInitialPrompt(agentConfig, sessionId, context);
+
+    const mcpServers = {
+      council: {
+        type: 'http' as const,
+        url: councilMcpUrl,
+        headers: {
+          'x-agent-token': agentToken,
+        },
+      },
+    };
+
+    this.emitLifecycle({ type: 'agent:started', agentId: agentConfig.id, sessionId });
+    this.registry.connect(agentConfig.id);
+    const startTime = Date.now();
+
+    try {
+      const abortController = new AbortController();
+      const timeout = setTimeout(() => abortController.abort(), this.timeoutMs);
+
+      try {
+        for await (const message of this.queryFn!({
+          prompt,
+          options: {
+            model: agentConfig.model ?? this.defaultModel,
+            systemPrompt,
+            maxTurns: this.maxTurns,
+            mcpServers,
+            allowedTools: ['mcp__council__*'],
+            permissionMode: 'bypassPermissions',
+            abortController,
+          },
+        }) as AsyncIterable<SdkMessage>) {
+          this.registry.touch(agentConfig.id);
+
+          if (message.type === 'result') {
+            const duration = Date.now() - startTime;
+            if (message.subtype === 'success') {
+              this.emitLifecycle({
+                type: 'agent:completed',
+                agentId: agentConfig.id,
+                sessionId,
+                durationMs: duration,
+                cost: message.total_cost_usd,
+              });
+            } else {
+              const errorMsg = message.errors?.join('; ') ?? `Agent ended with: ${message.subtype}`;
+              this.emitLifecycle({
+                type: 'agent:errored',
+                agentId: agentConfig.id,
+                sessionId,
+                error: errorMsg,
+              });
+            }
+          }
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      const duration = Date.now() - startTime;
+      this.emitLifecycle({
+        type: 'agent:errored',
+        agentId: agentConfig.id,
+        sessionId,
+        error: (err as Error).message,
+      });
+      // Re-throw for retry logic
+      if (!(err instanceof DOMException && err.name === 'AbortError')) {
+        throw err;
+      }
+      console.warn(`[SPAWN:SDK] Agent ${agentConfig.id} timed out after ${duration}ms`);
+    } finally {
+      this.registry.disconnect(agentConfig.id);
+    }
+  }
+
+  private buildSystemPrompt(agentConfig: AgentConfig, sessionId: string, agentToken: string): string {
+    return `${agentConfig.system_prompt}
+
+---
+
+## Council Operating Instructions
+
+You are participating in a council deliberation session (session: ${sessionId}).
+Your role on this council is: ${agentConfig.role}
+${agentConfig.expertise.length > 0 ? `Your areas of expertise: ${agentConfig.expertise.join(', ')}` : ''}
+
+You have access to the Council MCP server with the following tools:
+- council_get_context: Get your pending tasks and recent messages
+- council_get_session: Get full details for a specific session
+- council_send_message: Send a message to other council members
+- council_consult_agent: Request input from another board member
+- council_create_proposal: Create a formal proposal for deliberation
+- council_submit_findings: Submit investigation results
+- council_cast_vote: Vote on a proposal (approve/reject/abstain)
+- council_list_sessions: List active sessions
+
+For ALL tool calls, use agent_token: "${agentToken}"
+
+## Your workflow:
+1. Start by calling council_get_context to understand what is needed
+2. Review the session details with council_get_session
+3. Investigate the matter and submit your findings
+4. Discuss with other council members as needed
+5. When in voting phase, cast your vote with clear reasoning
+
+${agentConfig.can_veto ? 'You have VETO power. Use it only for critical issues.' : ''}
+${agentConfig.can_propose ? 'You can create formal proposals.' : 'You cannot create proposals, but you can discuss and vote.'}`;
+  }
+
+  private buildInitialPrompt(agentConfig: AgentConfig, sessionId: string, context: string): string {
+    return `You have been activated for council session ${sessionId}.
+
+Here is the context for this session:
+
+${context}
+
+Begin by calling council_get_context with your agent token to see your full briefing, then proceed according to your role as ${agentConfig.role}.`;
+  }
+
+  private emitLifecycle(event: AgentLifecycleEvent): void {
+    console.log(`[SPAWN:SDK] ${event.type}: agent=${event.agentId} session=${event.sessionId}${
+      event.type === 'agent:completed' ? ` duration=${event.durationMs}ms cost=$${event.cost ?? 'unknown'}` : ''
+    }${event.type === 'agent:errored' ? ` error=${event.error}` : ''}`);
+    this.onLifecycleEvent?.(event);
+  }
+}
+
+/** Minimal type for SDK messages we care about. */
+interface SdkMessage {
+  type: string;
+  subtype?: string;
+  total_cost_usd?: number;
+  errors?: string[];
 }
 
 /**
  * Create a spawner instance based on config.
  */
-export function createSpawner(config: SpawnerConfig): AgentSpawner {
+export function createSpawner(config: SpawnerConfig, registry?: AgentRegistry): AgentSpawner {
   switch (config.type) {
     case 'log':
       return new LogWebhookSpawner();
     case 'webhook':
       return new LogWebhookSpawner({ webhookUrl: config.webhook_url });
     case 'sdk':
-      return new AgentSdkSpawner();
+      if (!registry) {
+        throw new Error('AgentSdkSpawner requires an AgentRegistry instance');
+      }
+      return new AgentSdkSpawner({
+        registry,
+        defaultModel: config.default_model,
+        maxTurns: config.max_turns,
+        timeoutMs: config.timeout_ms,
+      });
     default:
       return new LogWebhookSpawner();
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -100,7 +100,7 @@ council:
   const messageBus = new MessageBus(config.council.communication_graph);
   const agentRegistry = new AgentRegistry();
   agentRegistry.loadAgents(config.council.agents);
-  const spawner = createSpawner(config.council.spawner);
+  const spawner = createSpawner(config.council.spawner, agentRegistry);
 
   const orchestrator = new Orchestrator({
     config,

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -51,6 +51,9 @@ const EventRoutingRuleSchema = z.object({
 const SpawnerConfigSchema = z.object({
   type: z.enum(['sdk', 'log', 'webhook']).default('log'),
   webhook_url: z.string().optional(),
+  default_model: z.string().optional(),
+  max_turns: z.number().int().min(1).optional(),
+  timeout_ms: z.number().int().min(1000).optional(),
 });
 
 const GithubConfigSchema = z.object({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,7 +74,17 @@ export interface EventRoutingRule {
 export interface SpawnerConfig {
   type: SpawnerType;
   webhook_url?: string;
+  default_model?: string;
+  max_turns?: number;
+  timeout_ms?: number;
 }
+
+// ── Agent lifecycle events ──
+
+export type AgentLifecycleEvent =
+  | { type: 'agent:started'; agentId: string; sessionId: string }
+  | { type: 'agent:completed'; agentId: string; sessionId: string; durationMs: number; cost?: number }
+  | { type: 'agent:errored'; agentId: string; sessionId: string; error: string };
 
 export interface GithubConfig {
   webhook_secret: string;

--- a/test/engine/spawner.test.ts
+++ b/test/engine/spawner.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LogWebhookSpawner, AgentSdkSpawner, createSpawner } from '@/engine/spawner.js';
+import { AgentRegistry } from '@/engine/agent-registry.js';
+import type { SpawnTask, AgentConfig, AgentLifecycleEvent } from '@/shared/types.js';
+
+// Mock the SDK
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+const { query: mockQuery } = await import('@anthropic-ai/claude-agent-sdk');
+const mockedQuery = vi.mocked(mockQuery);
+
+const agentConfig: AgentConfig = {
+  id: 'test-agent',
+  name: 'Test Agent',
+  role: 'Tester',
+  expertise: ['testing', 'qa'],
+  can_propose: true,
+  can_veto: false,
+  voting_weight: 1,
+  system_prompt: 'You are a test agent.',
+};
+
+const task: SpawnTask = {
+  sessionId: 'session-123',
+  agentConfig,
+  context: 'Test context for this session',
+  councilMcpUrl: 'http://localhost:3000/mcp',
+  agentToken: 'council_test-agent_abc123',
+};
+
+describe('LogWebhookSpawner', () => {
+  it('logs spawn details to console', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const spawner = new LogWebhookSpawner();
+    await spawner.spawn(task);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('[SPAWN] Agent test-agent'));
+    logSpy.mockRestore();
+  });
+
+  it('calls webhook URL when configured', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const spawner = new LogWebhookSpawner({ webhookUrl: 'http://example.com/hook' });
+    await spawner.spawn(task);
+    expect(fetchSpy).toHaveBeenCalledWith('http://example.com/hook', expect.objectContaining({
+      method: 'POST',
+    }));
+    fetchSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+});
+
+describe('AgentSdkSpawner', () => {
+  let registry: AgentRegistry;
+
+  beforeEach(() => {
+    registry = new AgentRegistry();
+    registry.loadAgents([agentConfig]);
+    vi.clearAllMocks();
+  });
+
+  it('calls query with correct MCP server config', async () => {
+    async function* mockGenerator() {
+      yield { type: 'result', subtype: 'success', result: 'done', total_cost_usd: 0.01 };
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const spawner = new AgentSdkSpawner({ registry });
+    await spawner.spawn(task);
+    // Allow background task to complete
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('session-123'),
+        options: expect.objectContaining({
+          mcpServers: {
+            council: {
+              type: 'http',
+              url: 'http://localhost:3000/mcp',
+              headers: { 'x-agent-token': 'council_test-agent_abc123' },
+            },
+          },
+          allowedTools: ['mcp__council__*'],
+          permissionMode: 'bypassPermissions',
+        }),
+      }),
+    );
+  });
+
+  it('includes agent system prompt and token', async () => {
+    async function* mockGenerator() {
+      yield { type: 'result', subtype: 'success', result: 'done' };
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const spawner = new AgentSdkSpawner({ registry });
+    await spawner.spawn(task);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const callArgs = mockedQuery.mock.calls[0][0] as any;
+    expect(callArgs.options.systemPrompt).toContain('You are a test agent.');
+    expect(callArgs.options.systemPrompt).toContain('council_test-agent_abc123');
+    expect(callArgs.options.systemPrompt).toContain('testing, qa');
+  });
+
+  it('uses custom model from agent config', async () => {
+    async function* mockGenerator() {
+      yield { type: 'result', subtype: 'success', result: 'done' };
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const customTask = {
+      ...task,
+      agentConfig: { ...agentConfig, model: 'claude-opus-4-6' },
+    };
+    const spawner = new AgentSdkSpawner({ registry });
+    await spawner.spawn(customTask);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const callArgs = mockedQuery.mock.calls[0][0] as any;
+    expect(callArgs.options.model).toBe('claude-opus-4-6');
+  });
+
+  it('emits lifecycle events', async () => {
+    const events: AgentLifecycleEvent[] = [];
+    async function* mockGenerator() {
+      yield { type: 'result', subtype: 'success', result: 'done', total_cost_usd: 0.05 };
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const spawner = new AgentSdkSpawner({
+      registry,
+      onLifecycleEvent: (e) => events.push(e),
+    });
+    await spawner.spawn(task);
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'agent:started', agentId: 'test-agent' }),
+        expect.objectContaining({ type: 'agent:completed', agentId: 'test-agent' }),
+      ]),
+    );
+  });
+
+  it('tracks agent connection in registry', async () => {
+    let resolveInner: () => void;
+    const innerDone = new Promise<void>((r) => { resolveInner = r; });
+
+    async function* mockGenerator() {
+      // Yield something to keep the generator alive briefly
+      yield { type: 'progress', text: 'working' };
+      yield { type: 'result', subtype: 'success', result: 'done' };
+      resolveInner!();
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const spawner = new AgentSdkSpawner({ registry });
+    await spawner.spawn(task);
+
+    // Wait for background task to complete
+    await innerDone;
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Agent should be disconnected after completion
+    expect(registry.isConnected('test-agent')).toBe(false);
+  });
+
+  it('handles SDK errors gracefully (fire-and-forget)', async () => {
+    mockedQuery.mockImplementation(() => {
+      throw new Error('SDK initialization failed');
+    });
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const spawner = new AgentSdkSpawner({ registry });
+    // spawn() should not throw — it's fire-and-forget
+    await expect(spawner.spawn(task)).resolves.toBeUndefined();
+
+    // Wait for retries to exhaust
+    await new Promise((r) => setTimeout(r, 5000));
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  }, 10000);
+
+  it('emits errored lifecycle on SDK failure', async () => {
+    const events: AgentLifecycleEvent[] = [];
+    async function* mockGenerator() {
+      yield { type: 'result', subtype: 'error_during_execution', errors: ['Something went wrong'] };
+    }
+    mockedQuery.mockReturnValue(mockGenerator() as any);
+
+    const spawner = new AgentSdkSpawner({
+      registry,
+      onLifecycleEvent: (e) => events.push(e),
+    });
+    await spawner.spawn(task);
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'agent:errored', agentId: 'test-agent' }),
+      ]),
+    );
+  });
+});
+
+describe('createSpawner', () => {
+  it('creates LogWebhookSpawner for type "log"', () => {
+    const spawner = createSpawner({ type: 'log' });
+    expect(spawner).toBeInstanceOf(LogWebhookSpawner);
+  });
+
+  it('creates LogWebhookSpawner with URL for type "webhook"', () => {
+    const spawner = createSpawner({ type: 'webhook', webhook_url: 'http://example.com' });
+    expect(spawner).toBeInstanceOf(LogWebhookSpawner);
+  });
+
+  it('creates AgentSdkSpawner for type "sdk" with registry', () => {
+    const registry = new AgentRegistry();
+    const spawner = createSpawner({ type: 'sdk' }, registry);
+    expect(spawner).toBeInstanceOf(AgentSdkSpawner);
+  });
+
+  it('throws if type "sdk" without registry', () => {
+    expect(() => createSpawner({ type: 'sdk' })).toThrow('AgentSdkSpawner requires an AgentRegistry');
+  });
+
+  it('passes SDK config options through', () => {
+    const registry = new AgentRegistry();
+    const spawner = createSpawner({
+      type: 'sdk',
+      default_model: 'claude-opus-4-6',
+      max_turns: 50,
+      timeout_ms: 60000,
+    }, registry);
+    expect(spawner).toBeInstanceOf(AgentSdkSpawner);
+  });
+
+  it('defaults to LogWebhookSpawner for unknown type', () => {
+    const spawner = createSpawner({ type: 'unknown' as any });
+    expect(spawner).toBeInstanceOf(LogWebhookSpawner);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `AgentSdkSpawner` using `@anthropic-ai/claude-agent-sdk` to launch autonomous Claude agents that connect back to Council via MCP HTTP transport
- Adds dynamic SDK import with graceful fallback to log-only mode when SDK is not installed
- Fire-and-forget spawning with retry logic (2 retries, exponential backoff), lifecycle event tracking, and timeout via `AbortController`
- Extends `SpawnerConfig` type and Zod schema with `default_model`, `max_turns`, `timeout_ms` options
- Adds `AgentLifecycleEvent` union type for tracking agent started/completed/errored events
- Updates `createSpawner()` factory to accept optional `AgentRegistry` (required for SDK spawner)
- 15 new tests covering SDK integration, lifecycle events, registry tracking, error handling, and factory function

## Test plan

- [x] All 66 tests pass (15 new spawner tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual test with `spawner.type: sdk` config and `ANTHROPIC_API_KEY` set
- [ ] Verify fallback behavior when SDK is not installed (`pnpm remove @anthropic-ai/claude-agent-sdk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)