### PR TITLE
Add escalation rule engine for autonomous error handling

### DIFF
--- a/config/examples/board-of-directors.yaml
+++ b/config/examples/board-of-directors.yaml
@@ -13,8 +13,47 @@ council:
     max_deliberation_rounds: 5
     require_human_approval: true
     escalation:
-      - condition: deadlock
-        action: escalate_to_human
+      - name: "deadlock_retry"
+        priority: 10
+        trigger:
+          type: deadlock
+        action:
+          type: restart_discussion
+        max_fires_per_session: 1
+
+      - name: "deadlock_escalate"
+        priority: 20
+        trigger:
+          type: quorum_not_met
+        action:
+          type: escalate_to_human
+          message: "Council could not reach quorum after retry"
+
+      - name: "veto_notify"
+        priority: 30
+        trigger:
+          type: veto_exercised
+        action:
+          type: escalate_to_human
+          message: "A veto was exercised — human review required"
+
+      - name: "discussion_timeout"
+        priority: 40
+        trigger:
+          type: timeout
+          phases: [discussion]
+          timeout_seconds: 600
+        action:
+          type: escalate_to_human
+          message: "Discussion phase timed out after 10 minutes"
+
+      - name: "max_rounds_auto_reject"
+        priority: 50
+        trigger:
+          type: max_rounds_exceeded
+        action:
+          type: auto_decide
+          forced_outcome: rejected
 
   agents:
     - id: cto

--- a/src/engine/escalation-engine.ts
+++ b/src/engine/escalation-engine.ts
@@ -1,0 +1,294 @@
+import { nanoid } from 'nanoid';
+import type {
+  CouncilConfig,
+  EscalationRule,
+  EscalationEvent,
+  EscalationTriggerType,
+  SessionPhase,
+  DecisionOutcome,
+} from '../shared/types.js';
+import type { Orchestrator, OrchestratorEvent } from './orchestrator.js';
+
+interface SessionTimerState {
+  sessionId: string;
+  phase: SessionPhase;
+  startedAt: number;
+  timeoutMs: number;
+  timerId: ReturnType<typeof setTimeout>;
+  ruleIndex: number;
+}
+
+export class EscalationEngine {
+  private config: CouncilConfig;
+  private orchestrator: Orchestrator;
+  private timers = new Map<string, SessionTimerState[]>();
+  private fireCounts = new Map<string, Map<number, number>>();
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(config: CouncilConfig, orchestrator: Orchestrator) {
+    this.config = config;
+    this.orchestrator = orchestrator;
+  }
+
+  /** Start listening to orchestrator events. */
+  start(): void {
+    this.unsubscribe = this.orchestrator.onEvent((event: OrchestratorEvent) => {
+      switch (event.type) {
+        case 'session:phase_changed':
+          this.onPhaseChanged(event.sessionId, event.phase);
+          break;
+        case 'session:created':
+        case 'message:new':
+        case 'vote:cast':
+        case 'decision:pending_review':
+        case 'event:received':
+        case 'escalation:triggered':
+          // No action needed for these events
+          break;
+      }
+    });
+  }
+
+  /** Stop all timers and unsubscribe. */
+  stop(): void {
+    // Cancel all timers
+    for (const [, timers] of this.timers) {
+      for (const timer of timers) {
+        clearTimeout(timer.timerId);
+      }
+    }
+    this.timers.clear();
+    this.fireCounts.clear();
+
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+
+  /** Evaluate escalation rules for a session with a given trigger. */
+  evaluate(sessionId: string, triggerType: EscalationTriggerType): void {
+    const rules = this.getSortedRules();
+
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      if (rule.trigger.type !== triggerType) continue;
+
+      // Check fire count limit
+      const sessionFires = this.fireCounts.get(sessionId);
+      const firedCount = sessionFires?.get(i) ?? 0;
+      if (firedCount >= (rule.max_fires_per_session ?? 1)) continue;
+
+      // Check phase filter for timeout rules
+      if (rule.trigger.phases && rule.trigger.phases.length > 0) {
+        const session = this.orchestrator.getSession(sessionId);
+        if (session && !rule.trigger.phases.includes(session.phase)) continue;
+      }
+
+      // Rule matches — execute the action
+      this.executeAction(sessionId, rule, i);
+
+      if (rule.stop_after) break;
+    }
+  }
+
+  /** Get active timers for a session (for debugging/UI). */
+  getActiveTimers(sessionId: string): Array<{ phase: string; remainingMs: number; ruleName: string }> {
+    const timers = this.timers.get(sessionId);
+    if (!timers) return [];
+
+    const now = Date.now();
+    return timers.map((t) => ({
+      phase: t.phase,
+      remainingMs: Math.max(0, t.timeoutMs - (now - t.startedAt)),
+      ruleName: this.getSortedRules()[t.ruleIndex]?.name ?? `rule_${t.ruleIndex}`,
+    }));
+  }
+
+  /** Get escalation events for a session. */
+  getEscalationEvents(sessionId: string): EscalationEvent[] {
+    return this.orchestrator.getEscalationEvents(sessionId);
+  }
+
+  private onPhaseChanged(sessionId: string, newPhase: SessionPhase): void {
+    // Cancel existing timers for this session
+    this.cancelTimers(sessionId);
+
+    // Clean up fire counts when session closes
+    if (newPhase === 'closed' || newPhase === 'decided') {
+      this.fireCounts.delete(sessionId);
+      return;
+    }
+
+    // Check for max_rounds_exceeded when entering discussion
+    if (newPhase === 'discussion') {
+      const session = this.orchestrator.getSession(sessionId);
+      if (session) {
+        const maxRounds = this.config.council.rules.max_deliberation_rounds;
+        if (session.deliberationRound > maxRounds) {
+          this.evaluate(sessionId, 'max_rounds_exceeded');
+        }
+      }
+    }
+
+    // Start new timers for timeout rules that match this phase
+    this.startTimersForPhase(sessionId, newPhase);
+  }
+
+  private startTimersForPhase(sessionId: string, phase: SessionPhase): void {
+    const rules = this.getSortedRules();
+
+    for (let i = 0; i < rules.length; i++) {
+      const rule = rules[i];
+      if (rule.trigger.type !== 'timeout') continue;
+      if (!rule.trigger.timeout_seconds) continue;
+
+      // Check if this timeout applies to the current phase
+      if (rule.trigger.phases && rule.trigger.phases.length > 0) {
+        if (!rule.trigger.phases.includes(phase)) continue;
+      }
+
+      // Check fire count
+      const sessionFires = this.fireCounts.get(sessionId);
+      const firedCount = sessionFires?.get(i) ?? 0;
+      if (firedCount >= (rule.max_fires_per_session ?? 1)) continue;
+
+      const timeoutMs = rule.trigger.timeout_seconds * 1000;
+      const timerId = setTimeout(() => {
+        this.evaluate(sessionId, 'timeout');
+      }, timeoutMs);
+
+      const timerState: SessionTimerState = {
+        sessionId,
+        phase,
+        startedAt: Date.now(),
+        timeoutMs,
+        timerId,
+        ruleIndex: i,
+      };
+
+      if (!this.timers.has(sessionId)) {
+        this.timers.set(sessionId, []);
+      }
+      this.timers.get(sessionId)!.push(timerState);
+    }
+  }
+
+  private cancelTimers(sessionId: string): void {
+    const timers = this.timers.get(sessionId);
+    if (timers) {
+      for (const timer of timers) {
+        clearTimeout(timer.timerId);
+      }
+      this.timers.delete(sessionId);
+    }
+  }
+
+  private executeAction(sessionId: string, rule: EscalationRule, ruleIndex: number): void {
+    // Record fire count
+    if (!this.fireCounts.has(sessionId)) {
+      this.fireCounts.set(sessionId, new Map());
+    }
+    const sessionFires = this.fireCounts.get(sessionId)!;
+    sessionFires.set(ruleIndex, (sessionFires.get(ruleIndex) ?? 0) + 1);
+
+    const escalationEvent: EscalationEvent = {
+      id: nanoid(),
+      sessionId,
+      ruleName: rule.name ?? `rule_${ruleIndex}`,
+      triggerType: rule.trigger.type,
+      actionType: rule.action.type,
+      details: `Escalation rule "${rule.name ?? ruleIndex}" triggered by ${rule.trigger.type}`,
+      createdAt: new Date().toISOString(),
+    };
+
+    console.log(`[ESCALATION] ${escalationEvent.details} for session ${sessionId}`);
+
+    switch (rule.action.type) {
+      case 'escalate_to_human':
+        this.actionEscalateToHuman(sessionId, rule, escalationEvent);
+        break;
+      case 'restart_discussion':
+        this.actionRestartDiscussion(sessionId, rule, escalationEvent);
+        break;
+      case 'add_agent':
+        this.actionAddAgent(sessionId, rule, escalationEvent);
+        break;
+      case 'auto_decide':
+        this.actionAutoDecide(sessionId, rule, escalationEvent);
+        break;
+      case 'notify_external':
+        this.actionNotifyExternal(sessionId, rule, escalationEvent);
+        break;
+    }
+  }
+
+  private actionEscalateToHuman(sessionId: string, rule: EscalationRule, event: EscalationEvent): void {
+    const message = rule.action.message ?? `Escalated: ${rule.trigger.type}`;
+    this.orchestrator.createEscalatedDecision(sessionId, message, event);
+  }
+
+  private actionRestartDiscussion(sessionId: string, rule: EscalationRule, event: EscalationEvent): void {
+    const session = this.orchestrator.getSession(sessionId);
+    if (!session) return;
+
+    this.orchestrator.saveEscalationEvent(event);
+
+    try {
+      this.orchestrator.transitionPhase(sessionId, 'discussion');
+    } catch {
+      console.warn(`[ESCALATION] Cannot restart discussion for session ${sessionId} from phase ${session.phase}`);
+    }
+  }
+
+  private actionAddAgent(sessionId: string, rule: EscalationRule, event: EscalationEvent): void {
+    const agentId = rule.action.agent_id;
+    if (!agentId) return;
+
+    this.orchestrator.saveEscalationEvent(event);
+
+    this.orchestrator.spawnAgentForEscalation(
+      sessionId,
+      agentId,
+      `You have been brought in via escalation. Reason: ${rule.trigger.type}. Review the session context and contribute.`,
+    ).catch((err) => {
+      console.error(`[ESCALATION] Failed to spawn agent ${agentId}: ${(err as Error).message}`);
+    });
+  }
+
+  private actionAutoDecide(sessionId: string, rule: EscalationRule, event: EscalationEvent): void {
+    const outcome = rule.action.forced_outcome ?? 'rejected';
+    this.orchestrator.createAutoDecision(
+      sessionId,
+      outcome,
+      `Auto-decided by escalation rule: ${rule.name ?? rule.trigger.type}`,
+      event,
+    );
+  }
+
+  private actionNotifyExternal(sessionId: string, rule: EscalationRule, event: EscalationEvent): void {
+    const url = rule.action.webhook_url;
+    if (!url) return;
+
+    this.orchestrator.saveEscalationEvent(event);
+
+    const session = this.orchestrator.getSession(sessionId);
+    const payload = rule.action.payload_template
+      ? { ...rule.action.payload_template, session, escalation: event }
+      : { session, escalation: event };
+
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch((err) => {
+      console.error(`[ESCALATION] External notification failed: ${(err as Error).message}`);
+    });
+  }
+
+  private getSortedRules(): EscalationRule[] {
+    return [...this.config.council.rules.escalation].sort(
+      (a, b) => (a.priority ?? 100) - (b.priority ?? 100),
+    );
+  }
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -121,6 +121,13 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
     }
   });
 
+  // ── Escalation Events ──
+
+  router.get('/sessions/:id/escalations', (req: Request, res: Response) => {
+    const escalations = orchestrator.getEscalationEvents(String(req.params.id));
+    res.json(escalations);
+  });
+
   // ── Events ──
 
   router.get('/events', (_req: Request, res: Response) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import { MessageBus } from '../engine/message-bus.js';
 import { AgentRegistry } from '../engine/agent-registry.js';
 import { createSpawner } from '../engine/spawner.js';
 import { Orchestrator } from '../engine/orchestrator.js';
+import { EscalationEngine } from '../engine/escalation-engine.js';
 import { createDb, DbStore } from './db.js';
 import { createMcpRouter } from './mcp-server.js';
 import { createWebhookRouter } from './webhooks.js';
@@ -112,6 +113,14 @@ council:
     store,
     mcpBaseUrl: MCP_BASE_URL,
   });
+
+  // ── Escalation Engine ──
+  if (config.council.rules.escalation.length > 0) {
+    const escalationEngine = new EscalationEngine(config, orchestrator);
+    orchestrator.setEscalationEngine(escalationEngine);
+    escalationEngine.start();
+    console.log(`[COUNCIL] Escalation engine started with ${config.council.rules.escalation.length} rule(s)`);
+  }
 
   console.log(`[COUNCIL] Orchestrator initialized with ${config.council.agents.length} agent(s)`);
 

--- a/src/server/ws.ts
+++ b/src/server/ws.ts
@@ -56,6 +56,8 @@ function toWsEvent(event: OrchestratorEvent): WsEvent | null {
       return { type: 'decision:pending_review', decision: event.decision };
     case 'event:received':
       return { type: 'event:received', event: event.event };
+    case 'escalation:triggered':
+      return { type: 'escalation:triggered', event: event.event };
     default:
       return null;
   }

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -1,4 +1,4 @@
-import type { Session, Message, Vote, Decision, IncomingEvent } from './types.js';
+import type { Session, Message, Vote, Decision, IncomingEvent, EscalationEvent } from './types.js';
 
 // ── WebSocket events (server → web UI) ──
 
@@ -9,6 +9,7 @@ export type WsEvent =
   | { type: 'vote:cast'; vote: Vote }
   | { type: 'decision:pending_review'; decision: Decision }
   | { type: 'event:received'; event: IncomingEvent }
+  | { type: 'escalation:triggered'; event: EscalationEvent }
   | { type: 'agent:connected'; agentId: string }
   | { type: 'agent:disconnected'; agentId: string };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,9 +49,54 @@ export interface CouncilRules {
   escalation: EscalationRule[];
 }
 
+// ── Escalation ──
+
+export type EscalationTriggerType =
+  | 'deadlock'
+  | 'quorum_not_met'
+  | 'veto_exercised'
+  | 'timeout'
+  | 'max_rounds_exceeded';
+
+export type EscalationActionType =
+  | 'escalate_to_human'
+  | 'restart_discussion'
+  | 'add_agent'
+  | 'auto_decide'
+  | 'notify_external';
+
+export interface EscalationTrigger {
+  type: EscalationTriggerType;
+  phases?: SessionPhase[];
+  timeout_seconds?: number;
+}
+
+export interface EscalationAction {
+  type: EscalationActionType;
+  message?: string;
+  agent_id?: string;
+  forced_outcome?: DecisionOutcome;
+  webhook_url?: string;
+  payload_template?: Record<string, unknown>;
+}
+
 export interface EscalationRule {
-  condition: string;
-  action: string;
+  name?: string;
+  priority?: number;
+  trigger: EscalationTrigger;
+  action: EscalationAction;
+  stop_after?: boolean;
+  max_fires_per_session?: number;
+}
+
+export interface EscalationEvent {
+  id: string;
+  sessionId: string;
+  ruleName: string;
+  triggerType: EscalationTriggerType;
+  actionType: EscalationActionType;
+  details: string;
+  createdAt: string;
 }
 
 export interface CommunicationGraph {

--- a/test/engine/escalation-engine.test.ts
+++ b/test/engine/escalation-engine.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EscalationEngine } from '@/engine/escalation-engine.js';
+import type { Orchestrator } from '@/engine/orchestrator.js';
+import type { CouncilConfig, EscalationEvent, Session, EscalationRule } from '@/shared/types.js';
+
+// Helper to create a minimal config with given escalation rules
+function createConfig(rules: EscalationRule[]): CouncilConfig {
+  return {
+    version: '1',
+    council: {
+      name: 'Test Council',
+      description: '',
+      spawner: { type: 'log' },
+      rules: {
+        quorum: 2,
+        voting_threshold: 0.5,
+        max_deliberation_rounds: 3,
+        require_human_approval: true,
+        escalation: rules,
+      },
+      agents: [
+        { id: 'agent-a', name: 'Agent A', role: 'Tester', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: 'Test' },
+        { id: 'agent-b', name: 'Agent B', role: 'Tester', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: 'Test' },
+      ],
+      communication_graph: { default_policy: 'broadcast', edges: {} },
+      event_routing: [],
+    },
+  };
+}
+
+function createMockSession(overrides?: Partial<Session>): Session {
+  return {
+    id: 'session-1',
+    councilId: 'council-1',
+    title: 'Test Session',
+    phase: 'voting',
+    leadAgentId: 'agent-a',
+    triggerEventId: null,
+    deliberationRound: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockOrchestrator() {
+  const listeners: Array<(event: unknown) => void> = [];
+  return {
+    onEvent: vi.fn((fn: (event: unknown) => void) => {
+      listeners.push(fn);
+      return () => {
+        const idx = listeners.indexOf(fn);
+        if (idx >= 0) listeners.splice(idx, 1);
+      };
+    }),
+    getSession: vi.fn(() => createMockSession()),
+    createEscalatedDecision: vi.fn(),
+    createAutoDecision: vi.fn(),
+    spawnAgentForEscalation: vi.fn().mockResolvedValue(undefined),
+    saveEscalationEvent: vi.fn(),
+    getEscalationEvents: vi.fn(() => []),
+    transitionPhase: vi.fn(),
+    _emit(event: unknown) {
+      for (const fn of listeners) fn(event);
+    },
+  } as unknown as Orchestrator & { _emit: (event: unknown) => void };
+}
+
+describe('EscalationEngine', () => {
+  let engine: EscalationEngine;
+  let orchestrator: ReturnType<typeof createMockOrchestrator>;
+
+  afterEach(() => {
+    engine?.stop();
+  });
+
+  describe('Rule evaluation', () => {
+    it('evaluates deadlock trigger and calls escalate_to_human', () => {
+      const config = createConfig([{
+        name: 'deadlock_escalate',
+        trigger: { type: 'deadlock' },
+        action: { type: 'escalate_to_human', message: 'Deadlocked' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(orchestrator.createEscalatedDecision).toHaveBeenCalledWith(
+        'session-1',
+        'Deadlocked',
+        expect.objectContaining({ triggerType: 'deadlock', actionType: 'escalate_to_human' }),
+      );
+    });
+
+    it('evaluates quorum_not_met trigger', () => {
+      const config = createConfig([{
+        trigger: { type: 'quorum_not_met' },
+        action: { type: 'escalate_to_human', message: 'No quorum' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'quorum_not_met');
+
+      expect(orchestrator.createEscalatedDecision).toHaveBeenCalledWith(
+        'session-1',
+        'No quorum',
+        expect.objectContaining({ triggerType: 'quorum_not_met' }),
+      );
+    });
+
+    it('evaluates veto_exercised trigger with add_agent action', () => {
+      const config = createConfig([{
+        trigger: { type: 'veto_exercised' },
+        action: { type: 'add_agent', agent_id: 'agent-b' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'veto_exercised');
+
+      expect(orchestrator.spawnAgentForEscalation).toHaveBeenCalledWith(
+        'session-1',
+        'agent-b',
+        expect.stringContaining('veto_exercised'),
+      );
+    });
+
+    it('evaluates auto_decide action with forced outcome', () => {
+      const config = createConfig([{
+        trigger: { type: 'max_rounds_exceeded' },
+        action: { type: 'auto_decide', forced_outcome: 'rejected' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'max_rounds_exceeded');
+
+      expect(orchestrator.createAutoDecision).toHaveBeenCalledWith(
+        'session-1',
+        'rejected',
+        expect.stringContaining('escalation rule'),
+        expect.objectContaining({ triggerType: 'max_rounds_exceeded' }),
+      );
+    });
+
+    it('evaluates restart_discussion action', () => {
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'restart_discussion' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(orchestrator.transitionPhase).toHaveBeenCalledWith('session-1', 'discussion');
+      expect(orchestrator.saveEscalationEvent).toHaveBeenCalled();
+    });
+
+    it('evaluates notify_external action', () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'notify_external', webhook_url: 'http://example.com/hook' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(fetchSpy).toHaveBeenCalledWith('http://example.com/hook', expect.objectContaining({
+        method: 'POST',
+      }));
+      fetchSpy.mockRestore();
+    });
+
+    it('ignores rules for non-matching trigger type', () => {
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'escalate_to_human' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'timeout');
+
+      expect(orchestrator.createEscalatedDecision).not.toHaveBeenCalled();
+    });
+
+    it('handles empty escalation config', () => {
+      const config = createConfig([]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      expect(() => engine.evaluate('session-1', 'deadlock')).not.toThrow();
+    });
+  });
+
+  describe('Priority and control flow', () => {
+    it('respects priority ordering (lower fires first)', () => {
+      const calls: string[] = [];
+      const config = createConfig([
+        { name: 'high', priority: 50, trigger: { type: 'deadlock' }, action: { type: 'escalate_to_human', message: 'high' } },
+        { name: 'low', priority: 10, trigger: { type: 'deadlock' }, action: { type: 'restart_discussion' } },
+      ]);
+      orchestrator = createMockOrchestrator();
+      // Track call order
+      (orchestrator.transitionPhase as ReturnType<typeof vi.fn>).mockImplementation(() => calls.push('restart_discussion'));
+      (orchestrator.createEscalatedDecision as ReturnType<typeof vi.fn>).mockImplementation(() => calls.push('escalate_to_human'));
+
+      engine = new EscalationEngine(config, orchestrator);
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(calls).toEqual(['restart_discussion', 'escalate_to_human']);
+    });
+
+    it('respects stop_after — only first matching rule fires', () => {
+      const config = createConfig([
+        { name: 'first', priority: 10, trigger: { type: 'deadlock' }, action: { type: 'restart_discussion' }, stop_after: true },
+        { name: 'second', priority: 20, trigger: { type: 'deadlock' }, action: { type: 'escalate_to_human' } },
+      ]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(orchestrator.transitionPhase).toHaveBeenCalled();
+      expect(orchestrator.createEscalatedDecision).not.toHaveBeenCalled();
+    });
+
+    it('respects max_fires_per_session', () => {
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'restart_discussion' },
+        max_fires_per_session: 1,
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+      engine.evaluate('session-1', 'deadlock');
+
+      expect(orchestrator.transitionPhase).toHaveBeenCalledTimes(1);
+    });
+
+    it('max_fires_per_session is per-session', () => {
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'restart_discussion' },
+        max_fires_per_session: 1,
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+
+      engine.evaluate('session-1', 'deadlock');
+      engine.evaluate('session-2', 'deadlock');
+
+      expect(orchestrator.transitionPhase).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Timer management', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('starts timer on phase change and fires after timeout', () => {
+      const config = createConfig([{
+        name: 'discussion_timeout',
+        trigger: { type: 'timeout', phases: ['discussion'], timeout_seconds: 10 },
+        action: { type: 'escalate_to_human', message: 'Timed out' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      (orchestrator.getSession as ReturnType<typeof vi.fn>).mockReturnValue(createMockSession({ phase: 'discussion' }));
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      // Simulate phase change
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      // Timer not yet fired
+      expect(orchestrator.createEscalatedDecision).not.toHaveBeenCalled();
+
+      // Advance past timeout
+      vi.advanceTimersByTime(10_000);
+
+      expect(orchestrator.createEscalatedDecision).toHaveBeenCalledWith(
+        'session-1',
+        'Timed out',
+        expect.objectContaining({ triggerType: 'timeout' }),
+      );
+    });
+
+    it('cancels timer on phase change', () => {
+      const config = createConfig([{
+        trigger: { type: 'timeout', phases: ['discussion'], timeout_seconds: 10 },
+        action: { type: 'escalate_to_human' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      (orchestrator.getSession as ReturnType<typeof vi.fn>).mockReturnValue(createMockSession({ phase: 'discussion' }));
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      // Move to voting before timeout fires
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'voting' });
+
+      vi.advanceTimersByTime(15_000);
+
+      // Timer was cancelled, should not fire
+      expect(orchestrator.createEscalatedDecision).not.toHaveBeenCalled();
+    });
+
+    it('does not start timer for non-matching phase', () => {
+      const config = createConfig([{
+        trigger: { type: 'timeout', phases: ['voting'], timeout_seconds: 10 },
+        action: { type: 'escalate_to_human' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      expect(engine.getActiveTimers('session-1')).toHaveLength(0);
+    });
+
+    it('getActiveTimers returns remaining time', () => {
+      const config = createConfig([{
+        name: 'my_timer',
+        trigger: { type: 'timeout', phases: ['discussion'], timeout_seconds: 60 },
+        action: { type: 'escalate_to_human' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      vi.advanceTimersByTime(10_000);
+
+      const timers = engine.getActiveTimers('session-1');
+      expect(timers).toHaveLength(1);
+      expect(timers[0].ruleName).toBe('my_timer');
+      expect(timers[0].remainingMs).toBeLessThanOrEqual(50_000);
+      expect(timers[0].remainingMs).toBeGreaterThan(0);
+    });
+
+    it('stop() cancels all timers', () => {
+      const config = createConfig([{
+        trigger: { type: 'timeout', phases: ['discussion'], timeout_seconds: 10 },
+        action: { type: 'escalate_to_human' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      engine.stop();
+      vi.advanceTimersByTime(15_000);
+
+      expect(orchestrator.createEscalatedDecision).not.toHaveBeenCalled();
+    });
+
+    it('cleans up fire counts when session closes', () => {
+      const config = createConfig([{
+        trigger: { type: 'deadlock' },
+        action: { type: 'restart_discussion' },
+        max_fires_per_session: 1,
+      }]);
+      orchestrator = createMockOrchestrator();
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      // Fire once
+      engine.evaluate('session-1', 'deadlock');
+      expect(orchestrator.transitionPhase).toHaveBeenCalledTimes(1);
+
+      // Simulate session closing (clears fire counts)
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'closed' });
+
+      // Should be able to fire again if session reopened (edge case)
+      engine.evaluate('session-1', 'deadlock');
+      expect(orchestrator.transitionPhase).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Phase-triggered evaluation', () => {
+    it('evaluates max_rounds_exceeded when entering discussion beyond limit', () => {
+      const config = createConfig([{
+        trigger: { type: 'max_rounds_exceeded' },
+        action: { type: 'auto_decide', forced_outcome: 'rejected' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      (orchestrator.getSession as ReturnType<typeof vi.fn>).mockReturnValue(
+        createMockSession({ phase: 'discussion', deliberationRound: 4 }),
+      );
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      expect(orchestrator.createAutoDecision).toHaveBeenCalledWith(
+        'session-1',
+        'rejected',
+        expect.any(String),
+        expect.objectContaining({ triggerType: 'max_rounds_exceeded' }),
+      );
+    });
+
+    it('does not trigger max_rounds_exceeded when within limit', () => {
+      const config = createConfig([{
+        trigger: { type: 'max_rounds_exceeded' },
+        action: { type: 'auto_decide', forced_outcome: 'rejected' },
+      }]);
+      orchestrator = createMockOrchestrator();
+      (orchestrator.getSession as ReturnType<typeof vi.fn>).mockReturnValue(
+        createMockSession({ phase: 'discussion', deliberationRound: 2 }),
+      );
+      engine = new EscalationEngine(config, orchestrator);
+      engine.start();
+
+      orchestrator._emit({ type: 'session:phase_changed', sessionId: 'session-1', phase: 'discussion' });
+
+      expect(orchestrator.createAutoDecision).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/shared/escalation-schema.test.ts
+++ b/test/shared/escalation-schema.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import { CouncilConfigSchema, validateAgentReferences } from '@/shared/schemas.js';
+
+describe('Escalation schema validation', () => {
+  const baseConfig = {
+    version: '1',
+    council: {
+      name: 'Test',
+      description: '',
+      spawner: { type: 'log' },
+      rules: {
+        quorum: 1,
+        voting_threshold: 0.5,
+      },
+      agents: [
+        { id: 'agent-a', name: 'A', role: 'Tester', system_prompt: 'Test' },
+      ],
+    },
+  };
+
+  it('validates well-formed escalation rule', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            name: 'test_rule',
+            priority: 10,
+            trigger: { type: 'deadlock' },
+            action: { type: 'escalate_to_human', message: 'Deadlocked' },
+            stop_after: true,
+            max_fires_per_session: 2,
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const rule = result.data.council.rules.escalation[0];
+      expect(rule.name).toBe('test_rule');
+      expect(rule.priority).toBe(10);
+      expect(rule.trigger.type).toBe('deadlock');
+      expect(rule.action.type).toBe('escalate_to_human');
+      expect(rule.stop_after).toBe(true);
+      expect(rule.max_fires_per_session).toBe(2);
+    }
+  });
+
+  it('rejects timeout trigger without timeout_seconds', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'timeout' },
+            action: { type: 'escalate_to_human' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts timeout trigger with timeout_seconds', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'timeout', timeout_seconds: 300, phases: ['discussion'] },
+            action: { type: 'escalate_to_human' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects add_agent action without agent_id', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'veto_exercised' },
+            action: { type: 'add_agent' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects notify_external without webhook_url', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'deadlock' },
+            action: { type: 'notify_external' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  it('applies default priority of 100', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'deadlock' },
+            action: { type: 'escalate_to_human' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.council.rules.escalation[0].priority).toBe(100);
+    }
+  });
+
+  it('applies default max_fires_per_session of 1', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'deadlock' },
+            action: { type: 'escalate_to_human' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.council.rules.escalation[0].max_fires_per_session).toBe(1);
+    }
+  });
+
+  it('backward compat: converts legacy { condition, action } format', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [
+            { condition: 'deadlock', action: 'escalate_to_human' },
+          ],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const rule = result.data.council.rules.escalation[0];
+      expect(rule.name).toBe('legacy_deadlock');
+      expect(rule.trigger.type).toBe('deadlock');
+      expect(rule.action.type).toBe('escalate_to_human');
+    }
+  });
+
+  it('validates agent references in escalation rules', () => {
+    const config = {
+      ...baseConfig,
+      council: {
+        ...baseConfig.council,
+        rules: {
+          ...baseConfig.council.rules,
+          escalation: [{
+            trigger: { type: 'veto_exercised' },
+            action: { type: 'add_agent', agent_id: 'nonexistent' },
+          }],
+        },
+      },
+    };
+
+    const result = CouncilConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const errors = validateAgentReferences(result.data);
+      expect(errors).toContainEqual(expect.stringContaining('nonexistent'));
+    }
+  });
+
+  it('accepts empty escalation array', () => {
+    const result = CouncilConfigSchema.safeParse(baseConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.council.rules.escalation).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces simple `{ condition, action }` escalation format with a structured rule engine
- **5 trigger types**: `deadlock`, `quorum_not_met`, `veto_exercised`, `timeout`, `max_rounds_exceeded`
- **5 action types**: `escalate_to_human`, `restart_discussion`, `add_agent`, `auto_decide`, `notify_external`
- Timer management for phase timeouts (auto-cancelled on phase transitions)
- Priority-based rule ordering, `stop_after` flow control, per-session fire limits
- Backward-compatible schema parsing — legacy `{ condition: "deadlock", action: "escalate_to_human" }` configs still work
- Orchestrator delegates deadlock/veto handling to the escalation engine when available
- Persists escalation events to new `escalation_events` table with REST API endpoint
- WebSocket broadcasts `escalation:triggered` events to connected UI clients
- Updated example board-of-directors.yaml with 5 structured escalation rules

## Test plan

- [x] 96 tests pass (30 new: 20 escalation engine + 10 schema validation)
- [x] TypeScript compiles cleanly
- [x] Backward compat: legacy config format parses successfully
- [x] Timer tests use fake timers for deterministic behavior
- [ ] Manual test: configure timeout rules and verify timers fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)