### PR TITLE
Add custom voting schemes with pluggable strategy pattern

### DIFF
--- a/src/engine/voting-schemes/advisory.ts
+++ b/src/engine/voting-schemes/advisory.ts
@@ -1,0 +1,21 @@
+import type { AgentConfig, CouncilRules, VoteValue } from '../../shared/types.js';
+import type { Ballot, TallyResult, VotingScheme } from './types.js';
+import { WeightedMajorityScheme } from './weighted-majority.js';
+
+export class AdvisoryScheme implements VotingScheme {
+  readonly name = 'advisory';
+  private inner = new WeightedMajorityScheme();
+
+  validVoteValues(): VoteValue[] {
+    return ['approve', 'reject', 'abstain'];
+  }
+
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult {
+    const inner = this.inner.tally(ballots, agents, rules);
+    return {
+      ...inner,
+      outcome: 'escalated', // Advisory is always non-binding
+      summary: `Advisory (non-binding): ${inner.summary}`,
+    };
+  }
+}

--- a/src/engine/voting-schemes/consent-based.ts
+++ b/src/engine/voting-schemes/consent-based.ts
@@ -1,0 +1,67 @@
+import type { AgentConfig, CouncilRules, DecisionOutcome, VoteValue } from '../../shared/types.js';
+import type { Ballot, TallyResult, VotingScheme } from './types.js';
+
+export class ConsentBasedScheme implements VotingScheme {
+  readonly name = 'consent_based';
+
+  validVoteValues(): VoteValue[] {
+    return ['consent', 'object', 'abstain'];
+  }
+
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult {
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    let consent = 0;
+    let object = 0;
+    let abstain = 0;
+    let totalWeight = 0;
+    let vetoExercised = false;
+
+    const objectors: string[] = [];
+
+    for (const ballot of ballots) {
+      const agent = agentMap.get(ballot.agentId);
+      const weight = agent?.voting_weight ?? 1;
+      totalWeight += weight;
+
+      switch (ballot.value) {
+        case 'consent':
+          consent += weight;
+          break;
+        case 'object':
+          object += weight;
+          objectors.push(ballot.agentId);
+          if (agent?.can_veto) vetoExercised = true;
+          break;
+        case 'abstain':
+          abstain += weight;
+          break;
+      }
+    }
+
+    const quorumMet = ballots.length >= rules.quorum;
+    const hasObjection = object > 0;
+    const thresholdMet = !hasObjection;
+
+    let outcome: DecisionOutcome | null = null;
+    if (quorumMet) {
+      outcome = hasObjection ? 'rejected' : 'approved';
+    }
+
+    const summary = hasObjection
+      ? `Objection raised by: ${objectors.join(', ')}. Consent not achieved.`
+      : `No objections — consent achieved. ${consent} consent, ${abstain} abstain.`;
+
+    return {
+      outcome,
+      quorumMet,
+      vetoExercised,
+      summary,
+      approve: consent,
+      reject: object,
+      abstain,
+      totalWeight,
+      thresholdMet,
+    };
+  }
+}

--- a/src/engine/voting-schemes/index.ts
+++ b/src/engine/voting-schemes/index.ts
@@ -1,0 +1,39 @@
+import type { VotingSchemeConfig } from '../../shared/types.js';
+import type { VotingScheme } from './types.js';
+import { WeightedMajorityScheme } from './weighted-majority.js';
+import { UnanimousScheme } from './unanimous.js';
+import { SupermajorityScheme } from './supermajority.js';
+import { ConsentBasedScheme } from './consent-based.js';
+import { AdvisoryScheme } from './advisory.js';
+
+export type { VotingScheme, Ballot, TallyResult } from './types.js';
+
+export function createVotingScheme(config?: VotingSchemeConfig): VotingScheme {
+  const type = config?.type ?? 'weighted_majority';
+
+  switch (type) {
+    case 'weighted_majority':
+      return new WeightedMajorityScheme();
+    case 'unanimous':
+      return new UnanimousScheme();
+    case 'supermajority':
+      return new SupermajorityScheme({
+        preset: config?.preset,
+        threshold: config?.threshold,
+      });
+    case 'consent_based':
+      return new ConsentBasedScheme();
+    case 'advisory':
+      return new AdvisoryScheme();
+    default:
+      return new WeightedMajorityScheme();
+  }
+}
+
+export {
+  WeightedMajorityScheme,
+  UnanimousScheme,
+  SupermajorityScheme,
+  ConsentBasedScheme,
+  AdvisoryScheme,
+};

--- a/src/engine/voting-schemes/supermajority.ts
+++ b/src/engine/voting-schemes/supermajority.ts
@@ -1,0 +1,90 @@
+import type { AgentConfig, CouncilRules, DecisionOutcome, VoteValue } from '../../shared/types.js';
+import type { Ballot, TallyResult, VotingScheme } from './types.js';
+
+const PRESETS: Record<string, number> = {
+  two_thirds: 2 / 3,
+  three_quarters: 3 / 4,
+};
+
+export class SupermajorityScheme implements VotingScheme {
+  readonly name = 'supermajority';
+  private threshold: number;
+
+  constructor(opts?: { preset?: string; threshold?: number }) {
+    if (opts?.threshold !== undefined) {
+      this.threshold = opts.threshold;
+    } else if (opts?.preset && PRESETS[opts.preset]) {
+      this.threshold = PRESETS[opts.preset];
+    } else {
+      this.threshold = 2 / 3; // default to two-thirds
+    }
+  }
+
+  validVoteValues(): VoteValue[] {
+    return ['approve', 'reject', 'abstain'];
+  }
+
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult {
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    let approve = 0;
+    let reject = 0;
+    let abstain = 0;
+    let totalWeight = 0;
+    let vetoExercised = false;
+
+    for (const ballot of ballots) {
+      const agent = agentMap.get(ballot.agentId);
+      const weight = agent?.voting_weight ?? 1;
+      totalWeight += weight;
+
+      switch (ballot.value) {
+        case 'approve':
+          approve += weight;
+          break;
+        case 'reject':
+          reject += weight;
+          if (agent?.can_veto) vetoExercised = true;
+          break;
+        case 'abstain':
+          abstain += weight;
+          break;
+      }
+    }
+
+    const quorumMet = ballots.length >= rules.quorum;
+    const votingWeight = approve + reject;
+    const thresholdMet = votingWeight > 0 && approve / votingWeight >= this.threshold;
+
+    let outcome: DecisionOutcome | null = null;
+    if (quorumMet) {
+      if (vetoExercised) {
+        outcome = 'rejected';
+      } else if (thresholdMet) {
+        outcome = 'approved';
+      } else {
+        outcome = 'rejected';
+      }
+    }
+
+    const pct = (this.threshold * 100).toFixed(0);
+    const parts = [
+      `Supermajority (${pct}%): Approve ${approve}, Reject ${reject}, Abstain ${abstain}`,
+      `Quorum: ${quorumMet ? 'met' : 'not met'}`,
+      `Threshold: ${thresholdMet ? 'met' : 'not met'}`,
+    ];
+    if (vetoExercised) parts.push('Veto exercised');
+
+    return {
+      outcome,
+      quorumMet,
+      vetoExercised,
+      summary: parts.join('. '),
+      approve,
+      reject,
+      abstain,
+      totalWeight,
+      thresholdMet,
+    };
+  }
+}

--- a/src/engine/voting-schemes/types.ts
+++ b/src/engine/voting-schemes/types.ts
@@ -1,0 +1,25 @@
+import type { AgentConfig, CouncilRules, DecisionOutcome, VoteValue } from '../../shared/types.js';
+
+export interface Ballot {
+  agentId: string;
+  value: VoteValue;
+  reasoning: string;
+}
+
+export interface TallyResult {
+  outcome: DecisionOutcome | null;
+  quorumMet: boolean;
+  vetoExercised: boolean;
+  summary: string;
+  approve: number;
+  reject: number;
+  abstain: number;
+  totalWeight: number;
+  thresholdMet: boolean;
+}
+
+export interface VotingScheme {
+  readonly name: string;
+  validVoteValues(): VoteValue[];
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult;
+}

--- a/src/engine/voting-schemes/unanimous.ts
+++ b/src/engine/voting-schemes/unanimous.ts
@@ -1,0 +1,61 @@
+import type { AgentConfig, CouncilRules, DecisionOutcome, VoteValue } from '../../shared/types.js';
+import type { Ballot, TallyResult, VotingScheme } from './types.js';
+
+export class UnanimousScheme implements VotingScheme {
+  readonly name = 'unanimous';
+
+  validVoteValues(): VoteValue[] {
+    return ['approve', 'reject', 'abstain'];
+  }
+
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult {
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    let approve = 0;
+    let reject = 0;
+    let abstain = 0;
+    let totalWeight = 0;
+    let vetoExercised = false;
+
+    for (const ballot of ballots) {
+      const agent = agentMap.get(ballot.agentId);
+      const weight = agent?.voting_weight ?? 1;
+      totalWeight += weight;
+
+      switch (ballot.value) {
+        case 'approve':
+          approve += weight;
+          break;
+        case 'reject':
+          reject += weight;
+          if (agent?.can_veto) vetoExercised = true;
+          break;
+        case 'abstain':
+          abstain += weight;
+          break;
+      }
+    }
+
+    const quorumMet = ballots.length >= rules.quorum;
+    const nonAbstaining = ballots.filter((b) => b.value !== 'abstain');
+    const allApprove = nonAbstaining.length > 0 && nonAbstaining.every((b) => b.value === 'approve');
+    const thresholdMet = allApprove;
+
+    let outcome: DecisionOutcome | null = null;
+    if (quorumMet) {
+      outcome = allApprove ? 'approved' : 'rejected';
+    }
+
+    return {
+      outcome,
+      quorumMet,
+      vetoExercised,
+      summary: `Unanimous: ${allApprove ? 'all approve' : 'not unanimous'}. ${nonAbstaining.length} non-abstaining vote(s)`,
+      approve,
+      reject,
+      abstain,
+      totalWeight,
+      thresholdMet,
+    };
+  }
+}

--- a/src/engine/voting-schemes/weighted-majority.ts
+++ b/src/engine/voting-schemes/weighted-majority.ts
@@ -1,0 +1,73 @@
+import type { AgentConfig, CouncilRules, DecisionOutcome, VoteValue } from '../../shared/types.js';
+import type { Ballot, TallyResult, VotingScheme } from './types.js';
+
+export class WeightedMajorityScheme implements VotingScheme {
+  readonly name = 'weighted_majority';
+
+  validVoteValues(): VoteValue[] {
+    return ['approve', 'reject', 'abstain'];
+  }
+
+  tally(ballots: Ballot[], agents: AgentConfig[], rules: CouncilRules): TallyResult {
+    const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+    let approve = 0;
+    let reject = 0;
+    let abstain = 0;
+    let totalWeight = 0;
+    let vetoExercised = false;
+
+    for (const ballot of ballots) {
+      const agent = agentMap.get(ballot.agentId);
+      const weight = agent?.voting_weight ?? 1;
+      totalWeight += weight;
+
+      switch (ballot.value) {
+        case 'approve':
+          approve += weight;
+          break;
+        case 'reject':
+          reject += weight;
+          if (agent?.can_veto) vetoExercised = true;
+          break;
+        case 'abstain':
+          abstain += weight;
+          break;
+      }
+    }
+
+    const quorumMet = ballots.length >= rules.quorum;
+    const votingWeight = approve + reject;
+    const thresholdMet = votingWeight > 0 && approve / votingWeight >= rules.voting_threshold;
+
+    let outcome: DecisionOutcome | null = null;
+    if (quorumMet) {
+      if (vetoExercised) {
+        outcome = 'rejected';
+      } else if (thresholdMet) {
+        outcome = 'approved';
+      } else {
+        outcome = 'rejected';
+      }
+    }
+
+    const parts = [
+      `Approve: ${approve}, Reject: ${reject}, Abstain: ${abstain}`,
+      `Quorum: ${quorumMet ? 'met' : 'not met'}`,
+      `Threshold: ${thresholdMet ? 'met' : 'not met'}`,
+    ];
+    if (vetoExercised) parts.push('Veto exercised');
+
+    return {
+      outcome,
+      quorumMet,
+      vetoExercised,
+      summary: parts.join('. '),
+      approve,
+      reject,
+      abstain,
+      totalWeight,
+      thresholdMet,
+    };
+  }
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -35,9 +35,16 @@ const EscalationRuleSchema = z.object({
   max_fires_per_session: z.number().int().positive().default(1),
 });
 
+const VotingSchemeConfigSchema = z.object({
+  type: z.enum(['weighted_majority', 'unanimous', 'supermajority', 'consent_based', 'advisory']).default('weighted_majority'),
+  preset: z.enum(['two_thirds', 'three_quarters']).optional(),
+  threshold: z.number().min(0).max(1).optional(),
+});
+
 const CouncilRulesSchema = z.object({
   quorum: z.number().int().min(1),
   voting_threshold: z.number().min(0).max(1),
+  voting_scheme: VotingSchemeConfigSchema.optional(),
   max_deliberation_rounds: z.number().int().min(1).default(5),
   require_human_approval: z.boolean().default(true),
   escalation: z.preprocess(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,7 +9,7 @@ export type SessionPhase =
   | 'decided'
   | 'closed';
 
-export type VoteValue = 'approve' | 'reject' | 'abstain';
+export type VoteValue = 'approve' | 'reject' | 'abstain' | 'consent' | 'object';
 
 export type DecisionOutcome = 'approved' | 'rejected' | 'escalated';
 
@@ -41,9 +41,25 @@ export interface AgentStatus {
 
 // ── Council ──
 
+// ── Voting schemes ──
+
+export type VotingSchemeName =
+  | 'weighted_majority'
+  | 'unanimous'
+  | 'supermajority'
+  | 'consent_based'
+  | 'advisory';
+
+export interface VotingSchemeConfig {
+  type: VotingSchemeName;
+  preset?: 'two_thirds' | 'three_quarters';
+  threshold?: number;
+}
+
 export interface CouncilRules {
   quorum: number;
   voting_threshold: number;
+  voting_scheme?: VotingSchemeConfig;
   max_deliberation_rounds: number;
   require_human_approval: boolean;
   escalation: EscalationRule[];

--- a/test/engine/voting-schemes.test.ts
+++ b/test/engine/voting-schemes.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import { createVotingScheme } from '@/engine/voting-schemes/index.js';
+import { WeightedMajorityScheme } from '@/engine/voting-schemes/weighted-majority.js';
+import { UnanimousScheme } from '@/engine/voting-schemes/unanimous.js';
+import { SupermajorityScheme } from '@/engine/voting-schemes/supermajority.js';
+import { ConsentBasedScheme } from '@/engine/voting-schemes/consent-based.js';
+import { AdvisoryScheme } from '@/engine/voting-schemes/advisory.js';
+import type { AgentConfig, CouncilRules } from '@/shared/types.js';
+import type { Ballot } from '@/engine/voting-schemes/types.js';
+
+const agents: AgentConfig[] = [
+  { id: 'a', name: 'A', role: 'A', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: '' },
+  { id: 'b', name: 'B', role: 'B', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: '' },
+  { id: 'c', name: 'C', role: 'C', expertise: [], can_propose: true, can_veto: true, voting_weight: 1.5, system_prompt: '' },
+];
+
+const rules: CouncilRules = {
+  quorum: 2,
+  voting_threshold: 0.66,
+  max_deliberation_rounds: 5,
+  require_human_approval: true,
+  escalation: [],
+};
+
+function ballot(agentId: string, value: string): Ballot {
+  return { agentId, value: value as Ballot['value'], reasoning: 'test' };
+}
+
+// ── Factory ──
+
+describe('createVotingScheme', () => {
+  it('defaults to weighted_majority when no config', () => {
+    const scheme = createVotingScheme();
+    expect(scheme.name).toBe('weighted_majority');
+  });
+
+  it('creates weighted_majority scheme', () => {
+    const scheme = createVotingScheme({ type: 'weighted_majority' });
+    expect(scheme).toBeInstanceOf(WeightedMajorityScheme);
+  });
+
+  it('creates unanimous scheme', () => {
+    const scheme = createVotingScheme({ type: 'unanimous' });
+    expect(scheme).toBeInstanceOf(UnanimousScheme);
+  });
+
+  it('creates supermajority scheme with preset', () => {
+    const scheme = createVotingScheme({ type: 'supermajority', preset: 'three_quarters' });
+    expect(scheme).toBeInstanceOf(SupermajorityScheme);
+    expect(scheme.name).toBe('supermajority');
+  });
+
+  it('creates supermajority scheme with custom threshold', () => {
+    const scheme = createVotingScheme({ type: 'supermajority', threshold: 0.8 });
+    expect(scheme).toBeInstanceOf(SupermajorityScheme);
+  });
+
+  it('creates consent_based scheme', () => {
+    const scheme = createVotingScheme({ type: 'consent_based' });
+    expect(scheme).toBeInstanceOf(ConsentBasedScheme);
+  });
+
+  it('creates advisory scheme', () => {
+    const scheme = createVotingScheme({ type: 'advisory' });
+    expect(scheme).toBeInstanceOf(AdvisoryScheme);
+  });
+
+  it('falls back to weighted_majority for unknown type', () => {
+    const scheme = createVotingScheme({ type: 'unknown' as any });
+    expect(scheme).toBeInstanceOf(WeightedMajorityScheme);
+  });
+});
+
+// ── Weighted Majority ──
+
+describe('WeightedMajorityScheme', () => {
+  const scheme = new WeightedMajorityScheme();
+
+  it('returns correct valid vote values', () => {
+    expect(scheme.validVoteValues()).toEqual(['approve', 'reject', 'abstain']);
+  });
+
+  it('approves when threshold met', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('approved');
+    expect(result.quorumMet).toBe(true);
+    expect(result.thresholdMet).toBe(true);
+  });
+
+  it('rejects when threshold not met', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('rejected');
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('returns null outcome when quorum not met', () => {
+    const ballots = [ballot('a', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBeNull();
+    expect(result.quorumMet).toBe(false);
+  });
+
+  it('applies voting weights', () => {
+    const ballots = [ballot('c', 'approve'), ballot('a', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.approve).toBe(1.5);
+    expect(result.reject).toBe(1);
+    // 1.5/2.5 = 0.6, below 0.66 threshold
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('handles veto power', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.vetoExercised).toBe(true);
+    expect(result.outcome).toBe('rejected');
+  });
+
+  it('includes summary text', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.summary).toContain('Approve: 2');
+    expect(result.summary).toContain('Quorum: met');
+    expect(result.summary).toContain('Threshold: met');
+  });
+});
+
+// ── Unanimous ──
+
+describe('UnanimousScheme', () => {
+  const scheme = new UnanimousScheme();
+
+  it('returns correct valid vote values', () => {
+    expect(scheme.validVoteValues()).toEqual(['approve', 'reject', 'abstain']);
+  });
+
+  it('approves when all non-abstaining approve', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('approved');
+    expect(result.thresholdMet).toBe(true);
+  });
+
+  it('approves when all non-abstaining approve (with abstains)', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'abstain'), ballot('c', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('approved');
+    expect(result.thresholdMet).toBe(true);
+  });
+
+  it('rejects when any non-abstaining rejects', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'reject'), ballot('c', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('rejected');
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('returns null outcome when quorum not met', () => {
+    const ballots = [ballot('a', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBeNull();
+  });
+
+  it('includes summary text', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.summary).toContain('Unanimous');
+    expect(result.summary).toContain('all approve');
+  });
+});
+
+// ── Supermajority ──
+
+describe('SupermajorityScheme', () => {
+  it('defaults to two-thirds threshold', () => {
+    const scheme = new SupermajorityScheme();
+    // 2 approve, 1 reject = 66.7% — exactly meets 2/3
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'reject')];
+    const result = scheme.tally(ballots, agents, { ...rules, quorum: 3 });
+    // approve weight: 2, reject weight: 1.5, total: 3.5
+    // 2/3.5 = 0.571 < 0.667 → rejected (because c has weight 1.5)
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('uses preset three_quarters', () => {
+    const scheme = new SupermajorityScheme({ preset: 'three_quarters' });
+    // Need >= 75% to pass. 3 approve, 1 reject:
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    // 3.5/3.5 = 100% >= 75%
+    expect(result.outcome).toBe('approved');
+  });
+
+  it('uses custom threshold', () => {
+    const scheme = new SupermajorityScheme({ threshold: 0.9 });
+    // Need >= 90%. 2 approve (weight 2), 1 reject (weight 1.5)
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    // 2/3.5 = 57.1% < 90%
+    expect(result.outcome).toBe('rejected');
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('threshold takes precedence over preset', () => {
+    const scheme = new SupermajorityScheme({ preset: 'three_quarters', threshold: 0.5 });
+    // threshold=0.5 should be used, not 0.75
+    const ballots = [ballot('a', 'approve'), ballot('b', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    // 1/2 = 50% >= 50%
+    expect(result.thresholdMet).toBe(true);
+    expect(result.outcome).toBe('approved');
+  });
+
+  it('handles veto', () => {
+    const scheme = new SupermajorityScheme();
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.vetoExercised).toBe(true);
+    expect(result.outcome).toBe('rejected');
+  });
+
+  it('includes percentage in summary', () => {
+    const scheme = new SupermajorityScheme({ preset: 'three_quarters' });
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.summary).toContain('75%');
+  });
+
+  it('returns correct valid vote values', () => {
+    const scheme = new SupermajorityScheme();
+    expect(scheme.validVoteValues()).toEqual(['approve', 'reject', 'abstain']);
+  });
+});
+
+// ── Consent-Based ──
+
+describe('ConsentBasedScheme', () => {
+  const scheme = new ConsentBasedScheme();
+
+  it('returns correct valid vote values', () => {
+    expect(scheme.validVoteValues()).toEqual(['consent', 'object', 'abstain']);
+  });
+
+  it('approves when no objections', () => {
+    const ballots = [ballot('a', 'consent'), ballot('b', 'consent'), ballot('c', 'consent')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('approved');
+    expect(result.thresholdMet).toBe(true);
+  });
+
+  it('approves with abstains and no objections', () => {
+    const ballots = [ballot('a', 'consent'), ballot('b', 'abstain'), ballot('c', 'consent')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('approved');
+  });
+
+  it('rejects when any agent objects', () => {
+    const ballots = [ballot('a', 'consent'), ballot('b', 'object'), ballot('c', 'consent')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('rejected');
+    expect(result.thresholdMet).toBe(false);
+  });
+
+  it('reports objectors in summary', () => {
+    const ballots = [ballot('a', 'consent'), ballot('b', 'object')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.summary).toContain('b');
+    expect(result.summary).toContain('Objection');
+  });
+
+  it('tracks veto on objection from veto agent', () => {
+    const ballots = [ballot('a', 'consent'), ballot('c', 'object')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.vetoExercised).toBe(true);
+  });
+
+  it('returns null outcome when quorum not met', () => {
+    const ballots = [ballot('a', 'consent')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBeNull();
+  });
+
+  it('maps consent to approve and object to reject in tally counts', () => {
+    const ballots = [ballot('a', 'consent'), ballot('b', 'object'), ballot('c', 'abstain')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.approve).toBe(1);   // consent count
+    expect(result.reject).toBe(1);    // object count
+    expect(result.abstain).toBe(1.5); // c has weight 1.5
+  });
+});
+
+// ── Advisory ──
+
+describe('AdvisoryScheme', () => {
+  const scheme = new AdvisoryScheme();
+
+  it('returns correct valid vote values', () => {
+    expect(scheme.validVoteValues()).toEqual(['approve', 'reject', 'abstain']);
+  });
+
+  it('always returns escalated outcome regardless of votes', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve'), ballot('c', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('escalated');
+  });
+
+  it('returns escalated even when votes would reject', () => {
+    const ballots = [ballot('a', 'reject'), ballot('b', 'reject')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.outcome).toBe('escalated');
+  });
+
+  it('prefixes summary with Advisory label', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'approve')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.summary).toMatch(/^Advisory \(non-binding\):/);
+  });
+
+  it('still tallies votes correctly for informational purposes', () => {
+    const ballots = [ballot('a', 'approve'), ballot('b', 'reject'), ballot('c', 'abstain')];
+    const result = scheme.tally(ballots, agents, rules);
+    expect(result.approve).toBe(1);
+    expect(result.reject).toBe(1);
+    expect(result.abstain).toBe(1.5);
+  });
+});


### PR DESCRIPTION
## Summary

- Implement 5 pluggable voting schemes behind a `VotingScheme` interface: **weighted majority** (default), **unanimous**, **supermajority** (configurable threshold/presets), **consent-based** (consent/object/abstain), and **advisory** (non-binding, always escalates)
- Orchestrator now creates voting schemes from council YAML config and validates vote values per active scheme
- MCP `council_cast_vote` tool accepts all vote types (approve/reject/abstain/consent/object) and a new `council_get_voting_info` tool lets agents discover the active scheme and valid values
- Factory function `createVotingScheme()` maps config to implementations with sane defaults

## Test plan

- [x] 41 new tests covering all 5 scheme implementations, factory function, edge cases (veto, quorum, weights, thresholds)
- [x] Full suite passes: 137 tests (96 existing + 41 new)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Verify consent-based and advisory flows work end-to-end with MCP agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)