### PR TITLE
Add platform features for external agent integration

### DIFF
--- a/config/examples/momentumeq-board.yaml
+++ b/config/examples/momentumeq-board.yaml
@@ -1,0 +1,138 @@
+version: "1"
+
+council:
+  name: "MomentumEQ Advisory Board"
+  description: "Cross-functional advisory board for product decisions, feature specs, and deployment plans"
+
+  spawner:
+    type: log
+
+  rules:
+    quorum: 3
+    voting_threshold: 0.6
+    max_deliberation_rounds: 5
+    require_human_approval: true
+    enable_refinement: true
+    voting_scheme:
+      type: weighted_majority
+    dynamic_weights:
+      enabled: true
+      expertise_match_bonus: 0.5
+      max_multiplier: 3.0
+    escalation:
+      - name: "deadlock_retry"
+        trigger: { type: deadlock }
+        action: { type: restart_discussion }
+        max_fires_per_session: 1
+      - name: "veto_escalate"
+        trigger: { type: veto_exercised }
+        action:
+          type: escalate_to_human
+          message: "Veto exercised — human review required"
+
+  agents:
+    - id: cto-cpo
+      name: "CTO/CPO"
+      role: "Chief Technology & Product Officer"
+      expertise: [architecture, security, scalability, product_strategy, feature_design, technical_debt]
+      can_propose: true
+      can_veto: true
+      voting_weight: 1.5
+      persistent: true
+      system_prompt: |
+        You are the CTO/CPO — responsible for technical architecture and product strategy.
+        Evaluate proposals for technical feasibility, security, scalability, and user value.
+
+    - id: cro
+      name: "CRO & Business Strategy"
+      role: "Chief Revenue Officer"
+      expertise: [business_strategy, revenue, market_analysis, partnerships, pricing]
+      can_propose: true
+      can_veto: false
+      voting_weight: 1.0
+      persistent: true
+      system_prompt: |
+        You are the CRO — responsible for revenue and business strategy.
+        Evaluate proposals for market fit, revenue impact, and business viability.
+
+    - id: legal
+      name: "Legal Counsel"
+      role: "General Counsel"
+      expertise: [compliance, data_privacy, terms_of_service, risk_assessment, contracts]
+      can_propose: true
+      can_veto: true
+      voting_weight: 1.0
+      persistent: true
+      system_prompt: |
+        You are Legal Counsel — responsible for compliance and risk management.
+        Flag legal risks, privacy concerns, and regulatory requirements.
+
+    - id: social-media
+      name: "Social Media"
+      role: "Social Media Director"
+      expertise: [social_media, content_strategy, brand, community, marketing]
+      can_propose: true
+      can_veto: false
+      voting_weight: 1.0
+      persistent: true
+      system_prompt: |
+        You are the Social Media Director — responsible for brand presence and content strategy.
+        Evaluate proposals for brand impact, messaging, and community engagement.
+
+    - id: infosec
+      name: "InfoSec"
+      role: "Chief Information Security Officer"
+      expertise: [security, infrastructure, compliance, incident_response, threat_modeling]
+      can_propose: true
+      can_veto: true
+      voting_weight: 1.0
+      persistent: true
+      system_prompt: |
+        You are the CISO — responsible for information security and infrastructure protection.
+        Evaluate proposals for security risks, attack surface, and compliance.
+
+    - id: cs-growth
+      name: "CS & Growth"
+      role: "Customer Success & Growth Lead"
+      expertise: [customer_success, onboarding, retention, growth, user_feedback]
+      can_propose: true
+      can_veto: false
+      voting_weight: 1.0
+      persistent: true
+      system_prompt: |
+        You are the CS & Growth Lead — responsible for customer success and growth.
+        Evaluate proposals for customer impact, onboarding experience, and retention.
+
+  communication_graph:
+    default_policy: broadcast
+    edges: {}
+
+  event_routing:
+    - match: { source: generic, type: feature_spec }
+      assign:
+        lead: cto-cpo
+        consult: [cro, cs-growth]
+        topics: [feature_design, product_strategy]
+
+    - match: { source: generic, type: security_review }
+      assign:
+        lead: infosec
+        consult: [cto-cpo, legal]
+        topics: [security, compliance]
+
+    - match: { source: generic, type: deployment_plan }
+      assign:
+        lead: cto-cpo
+        consult: [infosec, cs-growth]
+        topics: [architecture, infrastructure, scalability]
+
+    - match: { source: generic, type: marketing_campaign }
+      assign:
+        lead: social-media
+        consult: [cro, cs-growth]
+        topics: [social_media, brand, marketing]
+
+    - match: { source: generic }
+      assign:
+        lead: cto-cpo
+        consult: []

--- a/src/engine/agent-registry.ts
+++ b/src/engine/agent-registry.ts
@@ -86,6 +86,16 @@ export class AgentRegistry {
     return this.agents.get(agentId)?.persistentToken ?? null;
   }
 
+  /** Clear a persistent token for an agent. */
+  clearPersistentToken(agentId: string): void {
+    const agent = this.agents.get(agentId);
+    if (!agent) return;
+    if (agent.persistentToken) {
+      this.persistentTokenToAgent.delete(agent.persistentToken);
+      agent.persistentToken = null;
+    }
+  }
+
   /** Resolve an agent ID from a connection token (checks both per-session and persistent). */
   resolveToken(token: string): string | null {
     return this.tokenToAgent.get(token)

--- a/src/server/admin-api.ts
+++ b/src/server/admin-api.ts
@@ -1,5 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import type { UserStore } from './user-store.js';
+import type { DbStore } from './db.js';
+import type { AgentRegistry } from '../engine/agent-registry.js';
 import type { PublicUser } from '../shared/types.js';
 
 function toPublicUser(row: { id: string; email: string; displayName: string; role: string; totpVerified: number; createdAt: string }): PublicUser {
@@ -13,7 +15,7 @@ function toPublicUser(row: { id: string; email: string; displayName: string; rol
   };
 }
 
-export function createAdminRouter(userStore: UserStore): Router {
+export function createAdminRouter(userStore: UserStore, store?: DbStore, agentRegistry?: AgentRegistry, councilId?: string): Router {
   const router = Router();
 
   // GET /api/admin/users — list all users
@@ -123,6 +125,57 @@ export function createAdminRouter(userStore: UserStore): Router {
   router.delete('/api-keys/:id', (req: Request, res: Response) => {
     const keyId = String(req.params.id);
     userStore.deleteApiKey(keyId);
+    res.json({ status: 'deleted' });
+  });
+
+  // ── Agent Tokens ──
+
+  // GET /api/admin/agent-tokens — list all persistent agent tokens
+  router.get('/agent-tokens', (_req: Request, res: Response) => {
+    if (!store) {
+      res.status(501).json({ error: 'Agent token management not available' });
+      return;
+    }
+    const tokens = store.listAllPersistentTokens();
+    res.json(tokens);
+  });
+
+  // POST /api/admin/agent-tokens/:agentId — provision a persistent token for an agent
+  router.post('/agent-tokens/:agentId', (req: Request, res: Response) => {
+    if (!store || !agentRegistry || !councilId) {
+      res.status(501).json({ error: 'Agent token management not available' });
+      return;
+    }
+
+    const agentId = String(req.params.agentId);
+    const agent = agentRegistry.getAgent(agentId);
+    if (!agent) {
+      res.status(404).json({ error: `Agent "${agentId}" not found in config` });
+      return;
+    }
+
+    // Check if token already exists
+    const existing = store.getPersistentToken(agentId);
+    if (existing) {
+      res.status(409).json({ error: `Agent "${agentId}" already has a persistent token. Delete it first to re-provision.` });
+      return;
+    }
+
+    const token = agentRegistry.generatePersistentToken(agentId);
+    store.savePersistentToken(agentId, councilId, token);
+    res.status(201).json({ agentId, token });
+  });
+
+  // DELETE /api/admin/agent-tokens/:agentId — revoke a persistent token
+  router.delete('/agent-tokens/:agentId', (req: Request, res: Response) => {
+    if (!store || !agentRegistry) {
+      res.status(501).json({ error: 'Agent token management not available' });
+      return;
+    }
+
+    const agentId = String(req.params.agentId);
+    store.deletePersistentToken(agentId);
+    agentRegistry.clearPersistentToken(agentId);
     res.json({ status: 'deleted' });
   });
 

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -67,13 +67,17 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
   });
 
   router.post('/sessions', (req: Request, res: Response) => {
-    const { title } = req.body;
+    const { title, topics } = req.body;
     if (!title || typeof title !== 'string') {
       res.status(400).json({ error: 'Request body must include "title" string field' });
       return;
     }
+    if (topics !== undefined && (!Array.isArray(topics) || !topics.every((t: unknown) => typeof t === 'string'))) {
+      res.status(400).json({ error: '"topics" must be an array of strings' });
+      return;
+    }
 
-    const session = orchestrator.createSession({ title });
+    const session = orchestrator.createSession({ title, topics });
     res.status(201).json(session);
   });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -138,7 +138,7 @@ export function createApp(opts: CreateAppOptions): CouncilApp {
   });
 
   // Admin routes (require admin role)
-  app.use('/api/admin', auth.protect, auth.requireAdmin, createAdminRouter(userStore));
+  app.use('/api/admin', auth.protect, auth.requireAdmin, createAdminRouter(userStore, store, agentRegistry, councilId));
 
   // REST API (protected)
   app.use('/api', auth.protect, createApiRouter(orchestrator, store));

--- a/src/server/mcp-user-server.ts
+++ b/src/server/mcp-user-server.ts
@@ -96,9 +96,10 @@ function registerUserTools(
       inputSchema: {
         title: z.string().describe('Session title/topic'),
         lead_agent_id: z.string().optional().describe('Lead agent ID (optional)'),
+        topics: z.array(z.string()).optional().describe('Expertise tags for dynamic voting weights (optional)'),
       },
     },
-    async ({ title, lead_agent_id }, extra) => {
+    async ({ title, lead_agent_id, topics }, extra) => {
       const user = getUser(extra);
       if (!user) {
         return { content: [{ type: 'text', text: 'Error: Not authenticated' }], isError: true };
@@ -107,6 +108,7 @@ function registerUserTools(
         const session = orchestrator.createSession({
           title,
           leadAgentId: lead_agent_id ?? null,
+          topics,
         });
         return {
           content: [{

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -41,6 +41,12 @@ const VotingSchemeConfigSchema = z.object({
   threshold: z.number().min(0).max(1).optional(),
 });
 
+const DynamicWeightConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  expertise_match_bonus: z.number().positive().default(0.5),
+  max_multiplier: z.number().positive().default(3.0),
+});
+
 const CouncilRulesSchema = z.object({
   quorum: z.number().int().min(1),
   voting_threshold: z.number().min(0).max(1),
@@ -50,6 +56,7 @@ const CouncilRulesSchema = z.object({
   enable_refinement: z.boolean().default(true),
   max_amendments: z.number().int().min(1).default(10),
   amendment_resolution: z.enum(['lead_resolves', 'auto_accept']).default('lead_resolves'),
+  dynamic_weights: DynamicWeightConfigSchema.optional(),
   escalation: z.preprocess(
     (val) => {
       if (!Array.isArray(val)) return val;
@@ -96,6 +103,7 @@ const EventRoutingMatchSchema = z.object({
 const EventRoutingAssignSchema = z.object({
   lead: z.string(),
   consult: z.array(z.string()).default([]),
+  topics: z.array(z.string()).default([]),
 });
 
 const EventRoutingRuleSchema = z.object({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,6 +76,12 @@ export interface VotingSchemeConfig {
 export type AmendmentStatus = 'proposed' | 'accepted' | 'rejected';
 export type AmendmentResolution = 'lead_resolves' | 'auto_accept';
 
+export interface DynamicWeightConfig {
+  enabled: boolean;
+  expertise_match_bonus: number;
+  max_multiplier: number;
+}
+
 export interface CouncilRules {
   quorum: number;
   voting_threshold: number;
@@ -86,6 +92,7 @@ export interface CouncilRules {
   enable_refinement?: boolean;
   max_amendments?: number;
   amendment_resolution?: AmendmentResolution;
+  dynamic_weights?: DynamicWeightConfig;
 }
 
 // ── Escalation ──
@@ -152,6 +159,7 @@ export interface EventRoutingRule {
   assign: {
     lead: string;
     consult: string[];
+    topics?: string[];
   };
 }
 
@@ -209,6 +217,7 @@ export interface Session {
   triggerEventId: string | null;
   activeProposalId: string | null;
   deliberationRound: number;
+  topics: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/test/engine/dynamic-weights.test.ts
+++ b/test/engine/dynamic-weights.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Orchestrator, type OrchestratorStore } from '@/engine/orchestrator.js';
+import { EventRouter } from '@/engine/event-router.js';
+import { MessageBus } from '@/engine/message-bus.js';
+import { AgentRegistry } from '@/engine/agent-registry.js';
+import { LogWebhookSpawner } from '@/engine/spawner.js';
+import type { CouncilConfig, Session, Message, Vote, Decision, IncomingEvent, EscalationEvent } from '@/shared/types.js';
+
+function createMockStore(): OrchestratorStore & { _sessions: Map<string, Session> } {
+  const sessions = new Map<string, Session>();
+  const messageMap = new Map<string, Message[]>();
+  const voteMap = new Map<string, Vote[]>();
+  const decisionMap = new Map<string, Decision>();
+  const eventList: IncomingEvent[] = [];
+  const participantMap = new Map<string, Array<{ agentId: string; role: string }>>();
+
+  return {
+    _sessions: sessions,
+    saveSession: (s) => sessions.set(s.id, { ...s }),
+    updateSession: (id, updates) => {
+      const s = sessions.get(id);
+      if (s) sessions.set(id, { ...s, ...updates });
+    },
+    getSession: (id) => sessions.get(id) ?? null,
+    listSessions: (councilId, phase) => {
+      let list = Array.from(sessions.values());
+      if (councilId) list = list.filter((s) => s.councilId === councilId);
+      if (phase) list = list.filter((s) => s.phase === phase);
+      return list;
+    },
+    saveMessage: (m) => {
+      const list = messageMap.get(m.sessionId) ?? [];
+      list.push(m);
+      messageMap.set(m.sessionId, list);
+    },
+    updateMessage: (id, updates) => {
+      for (const [, msgs] of messageMap) {
+        const msg = msgs.find((m) => m.id === id);
+        if (msg) { Object.assign(msg, updates); break; }
+      }
+    },
+    getMessages: (sid) => messageMap.get(sid) ?? [],
+    saveVote: (v) => {
+      const list = voteMap.get(v.sessionId) ?? [];
+      list.push(v);
+      voteMap.set(v.sessionId, list);
+    },
+    getVotes: (sid) => [...(voteMap.get(sid) ?? [])],
+    saveDecision: (d) => decisionMap.set(d.sessionId, d),
+    getDecision: (sid) => decisionMap.get(sid) ?? null,
+    updateDecision: (id, updates) => {
+      for (const [sid, d] of decisionMap) {
+        if (d.id === id) {
+          decisionMap.set(sid, { ...d, ...updates });
+          break;
+        }
+      }
+    },
+    listPendingDecisions: () => {
+      return Array.from(decisionMap.values()).filter((d) => {
+        const s = sessions.get(d.sessionId);
+        return s?.phase === 'review';
+      });
+    },
+    saveEvent: (e) => eventList.push(e),
+    listEvents: (_cid, limit = 50) => eventList.slice(0, limit),
+    saveEscalationEvent: () => {},
+    getEscalationEvents: () => [],
+    addSessionParticipant: (sessionId, agentId, role) => {
+      const list = participantMap.get(sessionId) ?? [];
+      if (!list.some(p => p.agentId === agentId)) {
+        list.push({ agentId, role });
+        participantMap.set(sessionId, list);
+      }
+    },
+    getSessionParticipants: (sessionId) => participantMap.get(sessionId) ?? [],
+  };
+}
+
+describe('Dynamic Voting Weights', () => {
+  // Agents with different expertise areas
+  const configWithDynamicWeights: CouncilConfig = {
+    version: '1',
+    council: {
+      name: 'Test',
+      description: 'Test council',
+      spawner: { type: 'log' },
+      rules: {
+        quorum: 2,
+        voting_threshold: 0.5,
+        max_deliberation_rounds: 5,
+        require_human_approval: true,
+        enable_refinement: false,
+        escalation: [],
+        dynamic_weights: {
+          enabled: true,
+          expertise_match_bonus: 0.5,
+          max_multiplier: 3.0,
+        },
+      },
+      agents: [
+        { id: 'security', name: 'Security', role: 'CISO', expertise: ['security', 'compliance', 'infrastructure'], can_propose: true, can_veto: false, voting_weight: 1.0, system_prompt: '' },
+        { id: 'product', name: 'Product', role: 'CPO', expertise: ['product_strategy', 'feature_design', 'ux'], can_propose: true, can_veto: false, voting_weight: 1.0, system_prompt: '' },
+        { id: 'legal', name: 'Legal', role: 'Counsel', expertise: ['compliance', 'contracts', 'data_privacy'], can_propose: true, can_veto: false, voting_weight: 1.0, system_prompt: '' },
+      ],
+      communication_graph: { default_policy: 'broadcast', edges: {} },
+      event_routing: [],
+    },
+  };
+
+  let orchestrator: Orchestrator;
+  let store: OrchestratorStore & { _sessions: Map<string, Session> };
+
+  beforeEach(() => {
+    store = createMockStore();
+    const eventRouter = new EventRouter(configWithDynamicWeights.council.event_routing);
+    const messageBus = new MessageBus(configWithDynamicWeights.council.communication_graph);
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.loadAgents(configWithDynamicWeights.council.agents);
+
+    orchestrator = new Orchestrator({
+      config: configWithDynamicWeights,
+      councilId: 'test-council',
+      eventRouter,
+      messageBus,
+      agentRegistry,
+      spawner: new LogWebhookSpawner(),
+      store,
+      mcpBaseUrl: 'http://localhost:3000/mcp',
+    });
+  });
+
+  it('uses boosted weight for agents with matching expertise', () => {
+    // Session with security topics — the security agent should have boosted weight
+    const session = orchestrator.createSession({
+      title: 'Security review',
+      phase: 'proposal',
+      topics: ['security', 'compliance'],
+    });
+
+    expect(session.topics).toEqual(['security', 'compliance']);
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // Security agent: matches 2 topics → weight = 1.0 + 2*0.5 = 2.0
+    // Product agent: matches 0 → weight = 1.0
+    // Legal agent: matches 1 (compliance) → weight = 1.0 + 0.5 = 1.5
+    //
+    // security approves (weight 2.0), product rejects (weight 1.0), legal rejects (weight 1.5)
+    // Total approve weight: 2.0, total reject weight: 2.5
+    // Threshold: 2.0/4.5 ≈ 0.44 < 0.5 → rejected
+    orchestrator.castVote(session.id, 'security', 'approve', 'Looks secure');
+    orchestrator.castVote(session.id, 'product', 'reject', 'Not user-friendly');
+    orchestrator.castVote(session.id, 'legal', 'reject', 'Compliance concerns');
+
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('rejected');
+  });
+
+  it('uses static weights when no topics are set', () => {
+    const session = orchestrator.createSession({
+      title: 'General discussion',
+      phase: 'proposal',
+      topics: [],
+    });
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // All weights static (1.0 each)
+    // 2 approve (2.0), 1 reject (1.0) → 2/3 ≈ 0.66 >= 0.5 → approved
+    orchestrator.castVote(session.id, 'security', 'approve', 'OK');
+    orchestrator.castVote(session.id, 'product', 'approve', 'OK');
+    orchestrator.castVote(session.id, 'legal', 'reject', 'No');
+
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('approved');
+  });
+
+  it('caps effective weight at max_multiplier', () => {
+    // Agent with base weight 1.0, 3 matching topics → bonus 1.5
+    // Capped at 1.0 * 3.0 = 3.0
+    // Actual: min(1.0 + 1.5, 3.0) = 2.5 — not capped here
+    // With 6 matching topics: bonus 3.0, min(1.0 + 3.0, 3.0) = 3.0 — capped
+    const session = orchestrator.createSession({
+      title: 'Deep security session',
+      phase: 'proposal',
+      topics: ['security', 'compliance', 'infrastructure'],
+    });
+
+    expect(session.topics).toHaveLength(3);
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // Security agent matches all 3 topics → bonus 1.5 → effective weight = min(2.5, 3.0) = 2.5
+    // Product matches 0 → 1.0
+    // Legal matches 1 (compliance) → 1.0 + 0.5 = 1.5
+    //
+    // Security approves (2.5), product approves (1.0) → 3.5 approve
+    // Legal rejects (1.5) → total voting weight = 5.0
+    // Threshold: 3.5/5.0 = 0.7 >= 0.5 → approved
+    orchestrator.castVote(session.id, 'security', 'approve', 'Covers all bases');
+    orchestrator.castVote(session.id, 'product', 'approve', 'Fine by me');
+    orchestrator.castVote(session.id, 'legal', 'reject', 'Risk concerns');
+
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('approved');
+  });
+
+  it('defaults topics to empty array', () => {
+    const session = orchestrator.createSession({ title: 'No topics' });
+    expect(session.topics).toEqual([]);
+  });
+});
+
+describe('Dynamic Weights Disabled', () => {
+  const configWithoutDynamicWeights: CouncilConfig = {
+    version: '1',
+    council: {
+      name: 'Test',
+      description: 'Test council',
+      spawner: { type: 'log' },
+      rules: {
+        quorum: 2,
+        voting_threshold: 0.5,
+        max_deliberation_rounds: 5,
+        require_human_approval: true,
+        enable_refinement: false,
+        escalation: [],
+        // No dynamic_weights — feature disabled
+      },
+      agents: [
+        { id: 'a', name: 'A', role: 'A', expertise: ['security'], can_propose: true, can_veto: false, voting_weight: 1.0, system_prompt: '' },
+        { id: 'b', name: 'B', role: 'B', expertise: [], can_propose: true, can_veto: false, voting_weight: 1.0, system_prompt: '' },
+      ],
+      communication_graph: { default_policy: 'broadcast', edges: {} },
+      event_routing: [],
+    },
+  };
+
+  it('uses static weights when dynamic_weights is not configured', () => {
+    const store = createMockStore();
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.loadAgents(configWithoutDynamicWeights.council.agents);
+
+    const orchestrator = new Orchestrator({
+      config: configWithoutDynamicWeights,
+      councilId: 'test-council',
+      eventRouter: new EventRouter([]),
+      messageBus: new MessageBus({ default_policy: 'broadcast', edges: {} }),
+      agentRegistry,
+      spawner: new LogWebhookSpawner(),
+      store,
+      mcpBaseUrl: 'http://localhost:3000/mcp',
+    });
+
+    const session = orchestrator.createSession({
+      title: 'Test',
+      phase: 'proposal',
+      topics: ['security'],
+    });
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // Both have weight 1.0 regardless of expertise match
+    orchestrator.castVote(session.id, 'a', 'approve', 'Yes');
+    orchestrator.castVote(session.id, 'b', 'reject', 'No');
+
+    // 1 approve, 1 reject → 0.5 / 0.5 threshold → approved (>= 0.5)
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('approved');
+  });
+});

--- a/test/engine/orchestrator.test.ts
+++ b/test/engine/orchestrator.test.ts
@@ -12,6 +12,7 @@ function createMockStore(): OrchestratorStore {
   const voteMap = new Map<string, Vote[]>();
   const decisionMap = new Map<string, Decision>();
   const eventList: IncomingEvent[] = [];
+  const participantMap = new Map<string, Array<{ agentId: string; role: string }>>();
 
   return {
     saveSession: (s) => sessions.set(s.id, { ...s }),
@@ -43,7 +44,7 @@ function createMockStore(): OrchestratorStore {
       list.push(v);
       voteMap.set(v.sessionId, list);
     },
-    getVotes: (sid) => voteMap.get(sid) ?? [],
+    getVotes: (sid) => [...(voteMap.get(sid) ?? [])],
     saveDecision: (d) => decisionMap.set(d.sessionId, d),
     getDecision: (sid) => decisionMap.get(sid) ?? null,
     updateDecision: (id, updates) => {
@@ -64,6 +65,14 @@ function createMockStore(): OrchestratorStore {
     listEvents: (_cid, limit = 50) => eventList.slice(0, limit),
     saveEscalationEvent: () => {},
     getEscalationEvents: () => [],
+    addSessionParticipant: (sessionId, agentId, role) => {
+      const list = participantMap.get(sessionId) ?? [];
+      if (!list.some(p => p.agentId === agentId)) {
+        list.push({ agentId, role });
+        participantMap.set(sessionId, list);
+      }
+    },
+    getSessionParticipants: (sessionId) => participantMap.get(sessionId) ?? [],
   };
 }
 

--- a/test/engine/refinement.test.ts
+++ b/test/engine/refinement.test.ts
@@ -13,6 +13,7 @@ function createMockStore(): OrchestratorStore {
   const decisionMap = new Map<string, Decision>();
   const eventList: IncomingEvent[] = [];
   const escalationEvents: EscalationEvent[] = [];
+  const participantMap = new Map<string, Array<{ agentId: string; role: string }>>();
 
   return {
     saveSession: (s) => sessions.set(s.id, { ...s }),
@@ -47,7 +48,7 @@ function createMockStore(): OrchestratorStore {
       list.push(v);
       voteMap.set(v.sessionId, list);
     },
-    getVotes: (sid) => voteMap.get(sid) ?? [],
+    getVotes: (sid) => [...(voteMap.get(sid) ?? [])],
     saveDecision: (d) => decisionMap.set(d.sessionId, d),
     getDecision: (sid) => decisionMap.get(sid) ?? null,
     updateDecision: (id, updates) => {
@@ -68,6 +69,14 @@ function createMockStore(): OrchestratorStore {
     listEvents: (_cid, limit = 50) => eventList.slice(0, limit),
     saveEscalationEvent: (e) => escalationEvents.push(e),
     getEscalationEvents: (sid) => escalationEvents.filter((e) => e.sessionId === sid),
+    addSessionParticipant: (sessionId, agentId, role) => {
+      const list = participantMap.get(sessionId) ?? [];
+      if (!list.some(p => p.agentId === agentId)) {
+        list.push({ agentId, role });
+        participantMap.set(sessionId, list);
+      }
+    },
+    getSessionParticipants: (sessionId) => participantMap.get(sessionId) ?? [],
   };
 }
 

--- a/test/engine/session-participants.test.ts
+++ b/test/engine/session-participants.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Orchestrator, type OrchestratorStore } from '@/engine/orchestrator.js';
+import { EventRouter } from '@/engine/event-router.js';
+import { MessageBus } from '@/engine/message-bus.js';
+import { AgentRegistry } from '@/engine/agent-registry.js';
+import { LogWebhookSpawner } from '@/engine/spawner.js';
+import type { CouncilConfig, Session, Message, Vote, Decision, IncomingEvent, EscalationEvent } from '@/shared/types.js';
+
+function createMockStore(): OrchestratorStore & {
+  _sessions: Map<string, Session>;
+  _participants: Map<string, Array<{ agentId: string; role: string }>>;
+} {
+  const sessions = new Map<string, Session>();
+  const messageMap = new Map<string, Message[]>();
+  const voteMap = new Map<string, Vote[]>();
+  const decisionMap = new Map<string, Decision>();
+  const eventList: IncomingEvent[] = [];
+  const participantMap = new Map<string, Array<{ agentId: string; role: string }>>();
+
+  return {
+    _sessions: sessions,
+    _participants: participantMap,
+    saveSession: (s) => sessions.set(s.id, { ...s }),
+    updateSession: (id, updates) => {
+      const s = sessions.get(id);
+      if (s) sessions.set(id, { ...s, ...updates });
+    },
+    getSession: (id) => sessions.get(id) ?? null,
+    listSessions: (councilId, phase) => {
+      let list = Array.from(sessions.values());
+      if (councilId) list = list.filter((s) => s.councilId === councilId);
+      if (phase) list = list.filter((s) => s.phase === phase);
+      return list;
+    },
+    saveMessage: (m) => {
+      const list = messageMap.get(m.sessionId) ?? [];
+      list.push(m);
+      messageMap.set(m.sessionId, list);
+    },
+    updateMessage: (id, updates) => {
+      for (const [, msgs] of messageMap) {
+        const msg = msgs.find((m) => m.id === id);
+        if (msg) { Object.assign(msg, updates); break; }
+      }
+    },
+    getMessages: (sid) => messageMap.get(sid) ?? [],
+    saveVote: (v) => {
+      const list = voteMap.get(v.sessionId) ?? [];
+      list.push(v);
+      voteMap.set(v.sessionId, list);
+    },
+    getVotes: (sid) => [...(voteMap.get(sid) ?? [])],
+    saveDecision: (d) => decisionMap.set(d.sessionId, d),
+    getDecision: (sid) => decisionMap.get(sid) ?? null,
+    updateDecision: (id, updates) => {
+      for (const [sid, d] of decisionMap) {
+        if (d.id === id) {
+          decisionMap.set(sid, { ...d, ...updates });
+          break;
+        }
+      }
+    },
+    listPendingDecisions: () => {
+      return Array.from(decisionMap.values()).filter((d) => {
+        const s = sessions.get(d.sessionId);
+        return s?.phase === 'review';
+      });
+    },
+    saveEvent: (e) => eventList.push(e),
+    listEvents: (_cid, limit = 50) => eventList.slice(0, limit),
+    saveEscalationEvent: () => {},
+    getEscalationEvents: () => [],
+    addSessionParticipant: (sessionId, agentId, role) => {
+      const list = participantMap.get(sessionId) ?? [];
+      if (!list.some(p => p.agentId === agentId)) {
+        list.push({ agentId, role });
+        participantMap.set(sessionId, list);
+      }
+    },
+    getSessionParticipants: (sessionId) => participantMap.get(sessionId) ?? [],
+  };
+}
+
+const config: CouncilConfig = {
+  version: '1',
+  council: {
+    name: 'Test',
+    description: 'Test council',
+    spawner: { type: 'log' },
+    rules: {
+      quorum: 2,
+      voting_threshold: 0.5,
+      max_deliberation_rounds: 5,
+      require_human_approval: true,
+      escalation: [],
+    },
+    agents: [
+      { id: 'cto', name: 'CTO', role: 'CTO', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: '' },
+      { id: 'cpo', name: 'CPO', role: 'CPO', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: '' },
+      { id: 'cfo', name: 'CFO', role: 'CFO', expertise: [], can_propose: true, can_veto: false, voting_weight: 1, system_prompt: '' },
+    ],
+    communication_graph: { default_policy: 'broadcast', edges: {} },
+    event_routing: [
+      {
+        match: { source: 'generic', type: 'feature' },
+        assign: { lead: 'cto', consult: ['cpo'], topics: ['architecture'] },
+      },
+    ],
+  },
+};
+
+describe('Session Participants', () => {
+  let orchestrator: Orchestrator;
+  let store: OrchestratorStore & {
+    _sessions: Map<string, Session>;
+    _participants: Map<string, Array<{ agentId: string; role: string }>>;
+  };
+
+  beforeEach(() => {
+    store = createMockStore();
+    const eventRouter = new EventRouter(config.council.event_routing);
+    const messageBus = new MessageBus(config.council.communication_graph);
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.loadAgents(config.council.agents);
+
+    orchestrator = new Orchestrator({
+      config,
+      councilId: 'test-council',
+      eventRouter,
+      messageBus,
+      agentRegistry,
+      spawner: new LogWebhookSpawner(),
+      store,
+      mcpBaseUrl: 'http://localhost:3000/mcp',
+    });
+  });
+
+  it('records lead agent as participant on session creation', () => {
+    const session = orchestrator.createSession({
+      title: 'Test',
+      leadAgentId: 'cto',
+    });
+
+    const participants = store.getSessionParticipants(session.id);
+    expect(participants).toHaveLength(1);
+    expect(participants[0]).toEqual({ agentId: 'cto', role: 'lead' });
+  });
+
+  it('does not record participant when no lead is set', () => {
+    const session = orchestrator.createSession({ title: 'Test' });
+
+    const participants = store.getSessionParticipants(session.id);
+    expect(participants).toHaveLength(0);
+  });
+
+  it('records consulted agents as participants during webhook handling', async () => {
+    const session = await orchestrator.handleWebhookEvent({
+      source: 'generic',
+      eventType: 'feature',
+      payload: { description: 'New feature request' },
+    });
+
+    expect(session).not.toBeNull();
+    const participants = store.getSessionParticipants(session!.id);
+
+    // Should have lead (cto) and consult (cpo)
+    expect(participants).toHaveLength(2);
+    expect(participants.find(p => p.agentId === 'cto')).toEqual({ agentId: 'cto', role: 'lead' });
+    expect(participants.find(p => p.agentId === 'cpo')).toEqual({ agentId: 'cpo', role: 'consulted' });
+  });
+
+  it('concludes voting when all participants have voted (not all agents)', () => {
+    // Create session with only 2 of 3 agents as participants
+    const session = orchestrator.createSession({
+      title: 'Participant-scoped vote',
+      leadAgentId: 'cto',
+      phase: 'proposal',
+    });
+
+    // Manually add cpo as participant
+    store.addSessionParticipant(session.id, 'cpo', 'consulted');
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // Only cto and cpo are participants — cfo is NOT
+    orchestrator.castVote(session.id, 'cto', 'approve', 'Yes');
+    orchestrator.castVote(session.id, 'cpo', 'approve', 'Agreed');
+
+    // Voting should conclude with 2 votes (from participants), not wait for cfo
+    const updated = orchestrator.getSession(session.id);
+    expect(updated!.phase).toBe('review');
+
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('approved');
+  });
+
+  it('falls back to all agents when no participants are tracked', () => {
+    // Create session without lead — no participants recorded
+    const session = orchestrator.createSession({
+      title: 'No participants',
+      phase: 'proposal',
+    });
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    // Need all 3 agents to vote (fallback behavior)
+    orchestrator.castVote(session.id, 'cto', 'approve', 'Yes');
+    orchestrator.castVote(session.id, 'cpo', 'approve', 'Yes');
+
+    // 2 of 3 agents voted — should NOT conclude yet
+    let updated = orchestrator.getSession(session.id);
+    expect(updated!.phase).toBe('voting');
+
+    orchestrator.castVote(session.id, 'cfo', 'approve', 'Yes');
+
+    // Now all 3 voted — should conclude
+    updated = orchestrator.getSession(session.id);
+    expect(updated!.phase).toBe('review');
+  });
+
+  it('passes topics from routing rule to session', async () => {
+    const session = await orchestrator.handleWebhookEvent({
+      source: 'generic',
+      eventType: 'feature',
+      payload: { description: 'New feature' },
+    });
+
+    expect(session).not.toBeNull();
+    expect(session!.topics).toContain('architecture');
+  });
+
+  it('deduplicates participant entries', () => {
+    const session = orchestrator.createSession({
+      title: 'Test dedup',
+      leadAgentId: 'cto',
+    });
+
+    // Try to add cto again
+    store.addSessionParticipant(session.id, 'cto', 'consulted');
+
+    const participants = store.getSessionParticipants(session.id);
+    expect(participants).toHaveLength(1);
+  });
+
+  it('quorum checks work with participant count', () => {
+    // quorum = 2, so even with 2 participants, we need 2 votes
+    const session = orchestrator.createSession({
+      title: 'Quorum test',
+      leadAgentId: 'cto',
+      phase: 'proposal',
+    });
+    store.addSessionParticipant(session.id, 'cpo', 'consulted');
+
+    orchestrator.transitionPhase(session.id, 'discussion');
+    orchestrator.transitionPhase(session.id, 'voting');
+
+    orchestrator.castVote(session.id, 'cto', 'approve', 'Yes');
+    orchestrator.castVote(session.id, 'cpo', 'approve', 'Yes');
+
+    const decision = orchestrator.getDecision(session.id);
+    expect(decision).not.toBeNull();
+    expect(decision!.outcome).toBe('approved');
+  });
+});


### PR DESCRIPTION
## Summary

- **Session topics**: Sessions carry expertise tags (`topics: string[]`) from routing rules and event labels, enabling contextual voting weight adjustments
- **Dynamic voting weights**: Optional `dynamic_weights` config that boosts agent voting weight based on expertise-topic overlap at tally time (no changes to VotingScheme interface — all 5 existing schemes work unchanged)
- **Session participants tracking**: New `session_participants` table tracks which agents are assigned to each session; voting concludes when all participants have voted instead of waiting for all config agents
- **Admin agent token API**: `GET/POST/DELETE /api/admin/agent-tokens` for provisioning persistent tokens for externally-managed agents (e.g., Claude Cowork personas)
- **Example config**: `momentumeq-board.yaml` — a 6-agent advisory board demonstrating all new features
- **Test fix**: Mock store `getVotes()` now returns array copy to avoid mutable reference bug

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 265 tests pass (252 existing + 13 new)
- [ ] Manual: start dev server with `CONFIG_PATH=config/examples/momentumeq-board.yaml pnpm dev` and verify config loads
- [ ] Manual: create admin user, provision agent tokens via admin API, verify token list/revoke
- [ ] Manual: create session with topics, verify dynamic weight computation in vote tally

🤖 Generated with [Claude Code](https://claude.com/claude-code)