### PR TITLE
Add multi-council support with OrchestratorRegistry

### DIFF
--- a/src/engine/orchestrator-registry.ts
+++ b/src/engine/orchestrator-registry.ts
@@ -1,0 +1,132 @@
+import { EventRouter } from './event-router.js';
+import { MessageBus } from './message-bus.js';
+import { AgentRegistry } from './agent-registry.js';
+import { createSpawner } from './spawner.js';
+import { Orchestrator, type OrchestratorStore } from './orchestrator.js';
+import { EscalationEngine } from './escalation-engine.js';
+import type { CouncilConfig } from '../shared/types.js';
+
+export interface OrchestratorEntry {
+  orchestrator: Orchestrator;
+  config: CouncilConfig;
+  agentRegistry: AgentRegistry;
+  eventRouter: EventRouter;
+}
+
+/**
+ * Registry mapping councilId → Orchestrator + engine stack.
+ * Supports multiple councils running in a single server process.
+ */
+export class OrchestratorRegistry {
+  private entries = new Map<string, OrchestratorEntry>();
+  private defaultCouncilId: string | null = null;
+
+  /**
+   * Register a pre-built entry. First registered council becomes the default.
+   */
+  register(councilId: string, entry: OrchestratorEntry): void {
+    this.entries.set(councilId, entry);
+    if (this.defaultCouncilId === null) {
+      this.defaultCouncilId = councilId;
+    }
+  }
+
+  /**
+   * Build and register a full engine stack from a CouncilConfig.
+   * Extracts the construction logic that was previously inline in createApp().
+   */
+  create(
+    councilId: string,
+    config: CouncilConfig,
+    store: OrchestratorStore,
+    mcpBaseUrl: string,
+  ): OrchestratorEntry {
+    const eventRouter = new EventRouter(config.council.event_routing);
+    const messageBus = new MessageBus(config.council.communication_graph);
+    const agentRegistry = new AgentRegistry();
+    agentRegistry.loadAgents(config.council.agents);
+    const spawner = createSpawner(config.council.spawner, agentRegistry);
+
+    const orchestrator = new Orchestrator({
+      config,
+      councilId,
+      eventRouter,
+      messageBus,
+      agentRegistry,
+      spawner,
+      store,
+      mcpBaseUrl,
+    });
+
+    // Set up escalation engine if rules are defined
+    if (config.council.rules.escalation.length > 0) {
+      const escalationEngine = new EscalationEngine(config, orchestrator);
+      orchestrator.setEscalationEngine(escalationEngine);
+      escalationEngine.start();
+    }
+
+    const entry: OrchestratorEntry = {
+      orchestrator,
+      config,
+      agentRegistry,
+      eventRouter,
+    };
+
+    this.register(councilId, entry);
+    return entry;
+  }
+
+  /** Get an entry by councilId. */
+  get(councilId: string): OrchestratorEntry | null {
+    return this.entries.get(councilId) ?? null;
+  }
+
+  /** Remove a council from the registry. */
+  remove(councilId: string): boolean {
+    const deleted = this.entries.delete(councilId);
+    if (deleted && this.defaultCouncilId === councilId) {
+      // Pick a new default if available
+      const first = this.entries.keys().next();
+      this.defaultCouncilId = first.done ? null : first.value;
+    }
+    return deleted;
+  }
+
+  /** Get the default council entry. */
+  getDefault(): OrchestratorEntry | null {
+    if (!this.defaultCouncilId) return null;
+    return this.entries.get(this.defaultCouncilId) ?? null;
+  }
+
+  /** Get the default council ID. */
+  getDefaultId(): string | null {
+    return this.defaultCouncilId;
+  }
+
+  /** List all registered councils. */
+  list(): Array<{ councilId: string; entry: OrchestratorEntry }> {
+    return Array.from(this.entries.entries()).map(([councilId, entry]) => ({
+      councilId,
+      entry,
+    }));
+  }
+
+  /**
+   * Resolve an agent token across all councils.
+   * Returns the matching agentId, councilId, and entry.
+   */
+  resolveAgentToken(token: string): { agentId: string; councilId: string; entry: OrchestratorEntry } | null {
+    for (const [councilId, entry] of this.entries) {
+      const agentId = entry.agentRegistry.resolveToken(token);
+      if (agentId) {
+        return { agentId, councilId, entry };
+      }
+    }
+    return null;
+  }
+
+  /** Number of registered councils. */
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,15 +1,61 @@
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { OrchestratorRegistry, OrchestratorEntry } from '../engine/orchestrator-registry.js';
 import type { Orchestrator } from '../engine/orchestrator.js';
 import type { DbStore } from './db.js';
 import { parseConfig } from '../engine/config-loader.js';
 import { nanoid } from 'nanoid';
 import type { SessionPhase } from '../shared/types.js';
 
+// Augment Express Request to carry the resolved orchestrator entry
+declare module 'express' {
+  interface Request {
+    councilEntry?: OrchestratorEntry;
+    resolvedCouncilId?: string;
+  }
+}
+
+export interface ApiRouterOptions {
+  /** Called after a new council is created via POST /councils so the caller can wire MCP, WS, etc. */
+  onCouncilCreated?: (councilId: string, entry: OrchestratorEntry) => void;
+  /** Called after a council is deleted via DELETE /councils/:id. */
+  onCouncilDeleted?: (councilId: string) => void;
+}
+
 /**
  * REST API routes for the web UI.
  */
-export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Router {
+export function createApiRouter(
+  registry: OrchestratorRegistry,
+  store: DbStore,
+  opts?: ApiRouterOptions,
+): Router {
   const router = Router();
+
+  // Helper: resolve council from route param or query, falling back to default
+  function resolveOrchestrator(councilId: string | undefined): { orchestrator: Orchestrator; councilId: string } | null {
+    if (councilId) {
+      const entry = registry.get(councilId);
+      if (!entry) return null;
+      return { orchestrator: entry.orchestrator, councilId };
+    }
+    const defaultEntry = registry.getDefault();
+    const defaultId = registry.getDefaultId();
+    if (!defaultEntry || !defaultId) return null;
+    return { orchestrator: defaultEntry.orchestrator, councilId: defaultId };
+  }
+
+  // Middleware for council-scoped routes: resolve `:councilId` param
+  function resolveCouncilMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const councilId = String(req.params.councilId);
+    const entry = registry.get(councilId);
+    if (!entry) {
+      res.status(404).json({ error: 'Council not found' });
+      return;
+    }
+    req.councilEntry = entry;
+    req.resolvedCouncilId = councilId;
+    next();
+  }
 
   // ── Councils ──
 
@@ -21,6 +67,7 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
       description: c.description,
       agentCount: c.config.council.agents.length,
       createdAt: c.createdAt,
+      active: registry.get(c.id) !== null,
     })));
   });
 
@@ -33,14 +80,28 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
       }
 
       const config = parseConfig(yamlContent);
+      const councilId = nanoid();
       const council = {
-        id: nanoid(),
+        id: councilId,
         name: config.council.name,
         description: config.council.description,
         config,
         createdAt: new Date().toISOString(),
       };
       store.saveCouncil(council);
+
+      // Spin up a live orchestrator for this council
+      const mcpBaseUrl = `${req.protocol}://${req.get('host')}/mcp`;
+      const entry = registry.create(councilId, config, store, mcpBaseUrl);
+
+      // Persist council in DB
+      if (!store.getCouncil(councilId)) {
+        store.saveCouncil(council);
+      }
+
+      // Notify caller to wire up MCP notifications, WS subscriptions, etc.
+      opts?.onCouncilCreated?.(councilId, entry);
+
       res.status(201).json(council);
     } catch (err) {
       res.status(400).json({ error: (err as Error).message });
@@ -48,21 +109,114 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
   });
 
   router.get('/councils/:id', (req: Request, res: Response) => {
-    const council = store.getCouncil(String(req.params.id));
+    const councilId = String(req.params.id);
+    const council = store.getCouncil(councilId);
     if (!council) {
       res.status(404).json({ error: 'Council not found' });
       return;
     }
 
-    const agents = orchestrator.getAgentRegistry().getStatuses();
-    res.json({ ...council, agents });
+    const entry = registry.get(councilId);
+    const agents = entry?.agentRegistry.getStatuses() ?? [];
+    res.json({ ...council, agents, active: entry !== null });
   });
 
-  // ── Sessions ──
+  router.delete('/councils/:id', (req: Request, res: Response) => {
+    const councilId = String(req.params.id);
+    const council = store.getCouncil(councilId);
+    if (!council) {
+      res.status(404).json({ error: 'Council not found' });
+      return;
+    }
+
+    // Don't allow deleting the default council if it's the only one
+    if (registry.size <= 1 && registry.getDefaultId() === councilId) {
+      res.status(400).json({ error: 'Cannot delete the only active council' });
+      return;
+    }
+
+    registry.remove(councilId);
+    store.deleteCouncil(councilId);
+    opts?.onCouncilDeleted?.(councilId);
+
+    res.json({ status: 'deleted' });
+  });
+
+  // ── Council-scoped routes ──
+
+  router.get('/councils/:councilId/sessions', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const phase = req.query.phase as SessionPhase | undefined;
+    const sessions = req.councilEntry!.orchestrator.listSessions(phase);
+    res.json(sessions);
+  });
+
+  router.post('/councils/:councilId/sessions', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const { title, topics } = req.body;
+    if (!title || typeof title !== 'string') {
+      res.status(400).json({ error: 'Request body must include "title" string field' });
+      return;
+    }
+    if (topics !== undefined && (!Array.isArray(topics) || !topics.every((t: unknown) => typeof t === 'string'))) {
+      res.status(400).json({ error: '"topics" must be an array of strings' });
+      return;
+    }
+    const session = req.councilEntry!.orchestrator.createSession({ title, topics });
+    res.status(201).json(session);
+  });
+
+  router.get('/councils/:councilId/sessions/:id', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const session = req.councilEntry!.orchestrator.getSession(String(req.params.id));
+    if (!session) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+    const orch = req.councilEntry!.orchestrator;
+    const messages = orch.getMessages(session.id);
+    const votes = orch.getVotes(session.id);
+    const decision = orch.getDecision(session.id);
+    res.json({ session, messages, votes, decision });
+  });
+
+  router.post('/councils/:councilId/sessions/:id/review', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const { action, notes } = req.body;
+    if (!action) {
+      res.status(400).json({ error: 'Request body must include "action" field' });
+      return;
+    }
+    const reviewedBy = req.user?.displayName ?? req.body.reviewedBy ?? 'Unknown';
+    try {
+      req.councilEntry!.orchestrator.submitReview(String(req.params.id), action, reviewedBy, notes);
+      res.json({ status: 'ok' });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get('/councils/:councilId/events', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const events = req.councilEntry!.orchestrator.listEvents(50);
+    res.json(events);
+  });
+
+  router.get('/councils/:councilId/agents', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const agents = req.councilEntry!.agentRegistry.getStatuses();
+    res.json(agents);
+  });
+
+  router.get('/councils/:councilId/decisions', resolveCouncilMiddleware, (req: Request, res: Response) => {
+    const decisions = req.councilEntry!.orchestrator.listPendingDecisions();
+    res.json(decisions);
+  });
+
+  // ── Flat routes (backward compatible) — use ?councilId= query param or default council ──
 
   router.get('/sessions', (req: Request, res: Response) => {
     const phase = req.query.phase as SessionPhase | undefined;
-    const sessions = orchestrator.listSessions(phase);
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const sessions = resolved.orchestrator.listSessions(phase);
     res.json(sessions);
   });
 
@@ -77,20 +231,31 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
       return;
     }
 
-    const session = orchestrator.createSession({ title, topics });
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+
+    const session = resolved.orchestrator.createSession({ title, topics });
     res.status(201).json(session);
   });
 
   router.get('/sessions/:id', (req: Request, res: Response) => {
-    const session = orchestrator.getSession(String(req.params.id));
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const session = resolved.orchestrator.getSession(String(req.params.id));
     if (!session) {
       res.status(404).json({ error: 'Session not found' });
       return;
     }
 
-    const messages = orchestrator.getMessages(session.id);
-    const votes = orchestrator.getVotes(session.id);
-    const decision = orchestrator.getDecision(session.id);
+    const messages = resolved.orchestrator.getMessages(session.id);
+    const votes = resolved.orchestrator.getVotes(session.id);
+    const decision = resolved.orchestrator.getDecision(session.id);
 
     res.json({ session, messages, votes, decision });
   });
@@ -102,8 +267,14 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
       return;
     }
 
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+
     try {
-      orchestrator.transitionPhase(String(req.params.id), phase);
+      resolved.orchestrator.transitionPhase(String(req.params.id), phase);
       res.json({ status: 'ok', phase });
     } catch (err) {
       res.status(400).json({ error: (err as Error).message });
@@ -117,11 +288,17 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
       return;
     }
 
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+
     // Use authenticated user's name, fall back to body.reviewedBy for backward compat
     const reviewedBy = req.user?.displayName ?? req.body.reviewedBy ?? 'Unknown';
 
     try {
-      orchestrator.submitReview(String(req.params.id), action, reviewedBy, notes);
+      resolved.orchestrator.submitReview(String(req.params.id), action, reviewedBy, notes);
       res.json({ status: 'ok' });
     } catch (err) {
       res.status(400).json({ error: (err as Error).message });
@@ -131,8 +308,13 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
   // ── Amendments ──
 
   router.get('/sessions/:id/amendments', (req: Request, res: Response) => {
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
     const sessionId = String(req.params.id);
-    const messages = orchestrator.getMessages(sessionId);
+    const messages = resolved.orchestrator.getMessages(sessionId);
     const amendments = messages.filter((m) => m.messageType === 'amendment');
     res.json(amendments);
   });
@@ -140,28 +322,48 @@ export function createApiRouter(orchestrator: Orchestrator, store: DbStore): Rou
   // ── Escalation Events ──
 
   router.get('/sessions/:id/escalations', (req: Request, res: Response) => {
-    const escalations = orchestrator.getEscalationEvents(String(req.params.id));
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const escalations = resolved.orchestrator.getEscalationEvents(String(req.params.id));
     res.json(escalations);
   });
 
   // ── Events ──
 
-  router.get('/events', (_req: Request, res: Response) => {
-    const events = orchestrator.listEvents(50);
+  router.get('/events', (req: Request, res: Response) => {
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const events = resolved.orchestrator.listEvents(50);
     res.json(events);
   });
 
   // ── Agents ──
 
-  router.get('/agents', (_req: Request, res: Response) => {
-    const agents = orchestrator.getAgentRegistry().getStatuses();
+  router.get('/agents', (req: Request, res: Response) => {
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const agents = resolved.orchestrator.getAgentRegistry().getStatuses();
     res.json(agents);
   });
 
   // ── Decisions ──
 
-  router.get('/decisions', (_req: Request, res: Response) => {
-    const decisions = orchestrator.listPendingDecisions();
+  router.get('/decisions', (req: Request, res: Response) => {
+    const resolved = resolveOrchestrator(req.query.councilId as string | undefined);
+    if (!resolved) {
+      res.status(404).json({ error: 'No council available' });
+      return;
+    }
+    const decisions = resolved.orchestrator.listPendingDecisions();
     res.json(decisions);
   });
 

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -3,17 +3,17 @@ import type { Session, Message, Vote, Decision, IncomingEvent, EscalationEvent }
 // ── WebSocket events (server → web UI) ──
 
 export type WsEvent =
-  | { type: 'session:created'; session: Session }
-  | { type: 'session:phase_changed'; sessionId: string; phase: string }
-  | { type: 'message:new'; message: Message }
-  | { type: 'amendment:resolved'; sessionId: string; amendmentId: string; status: string }
-  | { type: 'vote:cast'; vote: Vote }
-  | { type: 'decision:pending_review'; decision: Decision }
-  | { type: 'event:received'; event: IncomingEvent }
-  | { type: 'escalation:triggered'; event: EscalationEvent }
-  | { type: 'agent:connected'; agentId: string }
-  | { type: 'agent:disconnected'; agentId: string }
-  | { type: 'agent:session_assigned'; agentId: string; sessionId: string };
+  | { type: 'session:created'; session: Session; councilId?: string }
+  | { type: 'session:phase_changed'; sessionId: string; phase: string; councilId?: string }
+  | { type: 'message:new'; message: Message; councilId?: string }
+  | { type: 'amendment:resolved'; sessionId: string; amendmentId: string; status: string; councilId?: string }
+  | { type: 'vote:cast'; vote: Vote; councilId?: string }
+  | { type: 'decision:pending_review'; decision: Decision; councilId?: string }
+  | { type: 'event:received'; event: IncomingEvent; councilId?: string }
+  | { type: 'escalation:triggered'; event: EscalationEvent; councilId?: string }
+  | { type: 'agent:connected'; agentId: string; councilId?: string }
+  | { type: 'agent:disconnected'; agentId: string; councilId?: string }
+  | { type: 'agent:session_assigned'; agentId: string; sessionId: string; councilId?: string };
 
 // ── Webhook event types ──
 

--- a/src/web/components/CouncilManagement.tsx
+++ b/src/web/components/CouncilManagement.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'preact/hooks';
+
+interface CouncilSummary {
+  id: string;
+  name: string;
+  description: string;
+  agentCount: number;
+  active: boolean;
+  createdAt: string;
+}
+
+interface Props {
+  councils: CouncilSummary[];
+  onCouncilCreated: () => void;
+  onCouncilDeleted: () => void;
+}
+
+export function CouncilManagement({ councils, onCouncilCreated, onCouncilDeleted }: Props) {
+  const [yaml, setYaml] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async () => {
+    if (!yaml.trim()) {
+      setError('YAML config is required');
+      return;
+    }
+
+    setCreating(true);
+    setError(null);
+
+    try {
+      const res = await fetch('/api/councils', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ yaml }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Failed to create council');
+        return;
+      }
+
+      setYaml('');
+      onCouncilCreated();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (councilId: string) => {
+    if (!confirm('Delete this council? This cannot be undone.')) return;
+
+    try {
+      const res = await fetch(`/api/councils/${councilId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.error || 'Failed to delete council');
+        return;
+      }
+      onCouncilDeleted();
+    } catch (err) {
+      alert((err as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <h2 style={{ fontSize: 20, fontWeight: 600, color: 'var(--text)' }}>Councils</h2>
+      </div>
+
+      {/* Council list */}
+      <div style={{ marginBottom: 32 }}>
+        {councils.map((c) => (
+          <div
+            key={c.id}
+            style={{
+              padding: '16px',
+              borderRadius: 'var(--radius)',
+              background: 'var(--surface)',
+              border: '1px solid var(--border)',
+              marginBottom: 8,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 600, color: 'var(--text)', fontSize: 14 }}>
+                {c.name}
+                {c.active && (
+                  <span style={{
+                    marginLeft: 8,
+                    fontSize: 11,
+                    padding: '1px 6px',
+                    borderRadius: 10,
+                    background: 'var(--success)',
+                    color: '#fff',
+                  }}>
+                    Active
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: 13, color: 'var(--text-dim)', marginTop: 4 }}>
+                {c.description}
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-dim)', marginTop: 4 }}>
+                {c.agentCount} agent{c.agentCount !== 1 ? 's' : ''} &middot; {c.id.slice(0, 12)}...
+              </div>
+            </div>
+            <button
+              onClick={() => handleDelete(c.id)}
+              style={{
+                background: 'none',
+                border: '1px solid var(--danger)',
+                color: 'var(--danger)',
+                padding: '4px 12px',
+                borderRadius: 'var(--radius)',
+                cursor: 'pointer',
+                fontSize: 13,
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ))}
+        {councils.length === 0 && (
+          <div style={{ color: 'var(--text-dim)', fontStyle: 'italic' }}>No councils configured.</div>
+        )}
+      </div>
+
+      {/* Create council */}
+      <div style={{
+        padding: 16,
+        borderRadius: 'var(--radius)',
+        background: 'var(--surface)',
+        border: '1px solid var(--border)',
+      }}>
+        <h3 style={{ fontSize: 16, fontWeight: 600, color: 'var(--text)', marginBottom: 12 }}>
+          Create Council
+        </h3>
+        <textarea
+          value={yaml}
+          onInput={(e) => setYaml((e.target as HTMLTextAreaElement).value)}
+          placeholder="Paste YAML council config here..."
+          style={{
+            width: '100%',
+            minHeight: 200,
+            padding: 12,
+            fontSize: 13,
+            fontFamily: 'monospace',
+            background: 'var(--surface-2)',
+            color: 'var(--text)',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius)',
+            resize: 'vertical',
+            boxSizing: 'border-box',
+          }}
+        />
+        {error && (
+          <div style={{ color: 'var(--danger)', fontSize: 13, marginTop: 8 }}>{error}</div>
+        )}
+        <button
+          onClick={handleCreate}
+          disabled={creating}
+          style={{
+            marginTop: 12,
+            padding: '8px 16px',
+            fontSize: 14,
+            background: 'var(--accent)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 'var(--radius)',
+            cursor: creating ? 'wait' : 'pointer',
+            opacity: creating ? 0.7 : 1,
+          }}
+        >
+          {creating ? 'Creating...' : 'Create Council'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/web/components/CouncilSelector.tsx
+++ b/src/web/components/CouncilSelector.tsx
@@ -1,0 +1,49 @@
+interface CouncilSummary {
+  id: string;
+  name: string;
+  description: string;
+  agentCount: number;
+  active: boolean;
+}
+
+interface Props {
+  councils: CouncilSummary[];
+  selectedCouncilId: string | null;
+  onSelect: (councilId: string | null) => void;
+}
+
+export function CouncilSelector({ councils, selectedCouncilId, onSelect }: Props) {
+  if (councils.length <= 1) return null;
+
+  return (
+    <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border)' }}>
+      <label style={{ fontSize: 11, color: 'var(--text-dim)', display: 'block', marginBottom: 4 }}>
+        Council
+      </label>
+      <select
+        value={selectedCouncilId ?? ''}
+        onChange={(e) => {
+          const val = (e.target as HTMLSelectElement).value;
+          onSelect(val || null);
+        }}
+        style={{
+          width: '100%',
+          padding: '6px 8px',
+          fontSize: 13,
+          background: 'var(--surface-2)',
+          color: 'var(--text)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius)',
+          cursor: 'pointer',
+        }}
+      >
+        <option value="">All Councils</option>
+        {councils.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name} ({c.agentCount} agents)
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/test/engine/orchestrator-registry.test.ts
+++ b/test/engine/orchestrator-registry.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OrchestratorRegistry } from '@/engine/orchestrator-registry.js';
+import { parseConfig } from '@/engine/config-loader.js';
+import type { OrchestratorStore } from '@/engine/orchestrator.js';
+import type { Session, Message, Vote, Decision, IncomingEvent, EscalationEvent, SessionPhase } from '@/shared/types.js';
+
+const YAML_A = `
+version: "1"
+council:
+  name: "Council A"
+  description: "First council"
+  spawner:
+    type: log
+  rules:
+    quorum: 1
+    voting_threshold: 0.5
+    max_deliberation_rounds: 3
+    require_human_approval: false
+    escalation: []
+  agents:
+    - id: agent-a
+      name: "Agent A"
+      role: "Lead"
+      system_prompt: "You are agent A."
+  event_routing: []
+  communication_graph:
+    default_policy: broadcast
+    edges: {}
+`;
+
+const YAML_B = `
+version: "1"
+council:
+  name: "Council B"
+  description: "Second council"
+  spawner:
+    type: log
+  rules:
+    quorum: 1
+    voting_threshold: 0.5
+    max_deliberation_rounds: 3
+    require_human_approval: false
+    escalation: []
+  agents:
+    - id: agent-b
+      name: "Agent B"
+      role: "Reviewer"
+      system_prompt: "You are agent B."
+  event_routing: []
+  communication_graph:
+    default_policy: broadcast
+    edges: {}
+`;
+
+function createMockStore(): OrchestratorStore {
+  const sessions = new Map<string, Session>();
+  const messages = new Map<string, Message[]>();
+  const voteStore = new Map<string, Vote[]>();
+  const decisions = new Map<string, Decision>();
+  const eventStore: IncomingEvent[] = [];
+  const escalationStore = new Map<string, EscalationEvent[]>();
+  const participants = new Map<string, Array<{ agentId: string; role: string }>>();
+
+  return {
+    saveSession: (s) => sessions.set(s.id, s),
+    updateSession: (id, updates) => {
+      const s = sessions.get(id);
+      if (s) sessions.set(id, { ...s, ...updates });
+    },
+    getSession: (id) => sessions.get(id) ?? null,
+    listSessions: (councilId?: string, phase?: SessionPhase) => {
+      let all = Array.from(sessions.values());
+      if (councilId) all = all.filter((s) => s.councilId === councilId);
+      if (phase) all = all.filter((s) => s.phase === phase);
+      return all;
+    },
+    saveMessage: (m) => {
+      const list = messages.get(m.sessionId) ?? [];
+      list.push(m);
+      messages.set(m.sessionId, list);
+    },
+    updateMessage: () => {},
+    getMessages: (sid) => [...(messages.get(sid) ?? [])],
+    saveVote: (v) => {
+      const list = voteStore.get(v.sessionId) ?? [];
+      list.push(v);
+      voteStore.set(v.sessionId, list);
+    },
+    getVotes: (sid) => [...(voteStore.get(sid) ?? [])],
+    saveDecision: (d) => decisions.set(d.sessionId, d),
+    getDecision: (sid) => decisions.get(sid) ?? null,
+    updateDecision: () => {},
+    listPendingDecisions: () => [],
+    saveEvent: (e) => eventStore.push(e),
+    listEvents: () => [...eventStore],
+    saveEscalationEvent: (e) => {
+      const list = escalationStore.get(e.sessionId) ?? [];
+      list.push(e);
+      escalationStore.set(e.sessionId, list);
+    },
+    getEscalationEvents: (sid) => [...(escalationStore.get(sid) ?? [])],
+    addSessionParticipant: (sid, agentId, role) => {
+      const list = participants.get(sid) ?? [];
+      if (!list.some(p => p.agentId === agentId)) {
+        list.push({ agentId, role });
+        participants.set(sid, list);
+      }
+    },
+    getSessionParticipants: (sid) => [...(participants.get(sid) ?? [])],
+  };
+}
+
+describe('OrchestratorRegistry', () => {
+  let registry: OrchestratorRegistry;
+  let store: OrchestratorStore;
+
+  beforeEach(() => {
+    registry = new OrchestratorRegistry();
+    store = createMockStore();
+  });
+
+  it('creates and registers a council', () => {
+    const config = parseConfig(YAML_A);
+    const entry = registry.create('council-a', config, store, 'http://localhost:0/mcp');
+
+    expect(registry.size).toBe(1);
+    expect(entry.orchestrator).toBeDefined();
+    expect(entry.config.council.name).toBe('Council A');
+    expect(entry.agentRegistry.getAgent('agent-a')).not.toBeNull();
+  });
+
+  it('first registered council becomes default', () => {
+    const configA = parseConfig(YAML_A);
+    const configB = parseConfig(YAML_B);
+
+    registry.create('council-a', configA, store, 'http://localhost:0/mcp');
+    registry.create('council-b', configB, store, 'http://localhost:0/mcp');
+
+    expect(registry.getDefaultId()).toBe('council-a');
+    expect(registry.getDefault()?.config.council.name).toBe('Council A');
+  });
+
+  it('gets entry by id', () => {
+    const config = parseConfig(YAML_A);
+    registry.create('council-a', config, store, 'http://localhost:0/mcp');
+
+    expect(registry.get('council-a')).not.toBeNull();
+    expect(registry.get('nonexistent')).toBeNull();
+  });
+
+  it('removes a council', () => {
+    const configA = parseConfig(YAML_A);
+    const configB = parseConfig(YAML_B);
+
+    registry.create('council-a', configA, store, 'http://localhost:0/mcp');
+    registry.create('council-b', configB, store, 'http://localhost:0/mcp');
+
+    expect(registry.remove('council-a')).toBe(true);
+    expect(registry.size).toBe(1);
+    expect(registry.get('council-a')).toBeNull();
+    // Default should switch to council-b
+    expect(registry.getDefaultId()).toBe('council-b');
+  });
+
+  it('remove returns false for unknown council', () => {
+    expect(registry.remove('nonexistent')).toBe(false);
+  });
+
+  it('lists all councils', () => {
+    const configA = parseConfig(YAML_A);
+    const configB = parseConfig(YAML_B);
+
+    registry.create('council-a', configA, store, 'http://localhost:0/mcp');
+    registry.create('council-b', configB, store, 'http://localhost:0/mcp');
+
+    const list = registry.list();
+    expect(list).toHaveLength(2);
+    expect(list.map(l => l.councilId).sort()).toEqual(['council-a', 'council-b']);
+  });
+
+  it('resolves agent token across councils', () => {
+    const configA = parseConfig(YAML_A);
+    const configB = parseConfig(YAML_B);
+
+    registry.create('council-a', configA, store, 'http://localhost:0/mcp');
+    registry.create('council-b', configB, store, 'http://localhost:0/mcp');
+
+    // Generate a token for agent-a in council-a
+    const entryA = registry.get('council-a')!;
+    const token = entryA.agentRegistry.generateToken('agent-a');
+
+    const result = registry.resolveAgentToken(token);
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('agent-a');
+    expect(result!.councilId).toBe('council-a');
+  });
+
+  it('resolveAgentToken returns null for unknown token', () => {
+    const config = parseConfig(YAML_A);
+    registry.create('council-a', config, store, 'http://localhost:0/mcp');
+
+    expect(registry.resolveAgentToken('fake_token')).toBeNull();
+  });
+
+  it('councils have independent sessions', () => {
+    const configA = parseConfig(YAML_A);
+    const configB = parseConfig(YAML_B);
+
+    registry.create('council-a', configA, store, 'http://localhost:0/mcp');
+    registry.create('council-b', configB, store, 'http://localhost:0/mcp');
+
+    const orchA = registry.get('council-a')!.orchestrator;
+    const orchB = registry.get('council-b')!.orchestrator;
+
+    orchA.createSession({ title: 'Session in A' });
+    orchB.createSession({ title: 'Session in B' });
+    orchB.createSession({ title: 'Another in B' });
+
+    expect(orchA.listSessions()).toHaveLength(1);
+    expect(orchB.listSessions()).toHaveLength(2);
+    expect(orchA.listSessions()[0].title).toBe('Session in A');
+  });
+
+  it('register allows adding pre-built entries', () => {
+    const configA = parseConfig(YAML_A);
+    const entry = registry.create('temp', configA, store, 'http://localhost:0/mcp');
+
+    const registry2 = new OrchestratorRegistry();
+    registry2.register('my-council', entry);
+    expect(registry2.size).toBe(1);
+    expect(registry2.getDefaultId()).toBe('my-council');
+  });
+
+  it('default is null when registry is empty', () => {
+    expect(registry.getDefault()).toBeNull();
+    expect(registry.getDefaultId()).toBeNull();
+  });
+
+  it('removing the only council clears the default', () => {
+    const config = parseConfig(YAML_A);
+    registry.create('council-a', config, store, 'http://localhost:0/mcp');
+    registry.remove('council-a');
+
+    expect(registry.getDefault()).toBeNull();
+    expect(registry.getDefaultId()).toBeNull();
+    expect(registry.size).toBe(0);
+  });
+});

--- a/test/integration/multi-council.test.ts
+++ b/test/integration/multi-council.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parseConfig } from '@/engine/config-loader.js';
+import { createApp, type CouncilApp } from '@/server/index.js';
+
+const YAML_ALPHA = `
+version: "1"
+council:
+  name: "Alpha Council"
+  description: "First test council"
+  spawner:
+    type: log
+  rules:
+    quorum: 1
+    voting_threshold: 0.5
+    max_deliberation_rounds: 3
+    require_human_approval: true
+    escalation: []
+  agents:
+    - id: alpha-lead
+      name: "Alpha Lead"
+      role: "Lead"
+      system_prompt: "You are the alpha lead."
+  event_routing:
+    - match:
+        source: generic
+        type: alpha.event
+      assign:
+        lead: alpha-lead
+        consult: []
+  communication_graph:
+    default_policy: broadcast
+    edges: {}
+`;
+
+const YAML_BETA = `
+version: "1"
+council:
+  name: "Beta Council"
+  description: "Second test council"
+  spawner:
+    type: log
+  rules:
+    quorum: 1
+    voting_threshold: 0.5
+    max_deliberation_rounds: 3
+    require_human_approval: true
+    escalation: []
+  agents:
+    - id: beta-lead
+      name: "Beta Lead"
+      role: "Lead"
+      system_prompt: "You are the beta lead."
+  event_routing:
+    - match:
+        source: generic
+        type: beta.event
+      assign:
+        lead: beta-lead
+        consult: []
+  communication_graph:
+    default_policy: broadcast
+    edges: {}
+`;
+
+let council: CouncilApp;
+let baseUrl: string;
+let tmpDir: string;
+let sessionCookie: string;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'council-multi-'));
+  const configAlpha = parseConfig(YAML_ALPHA);
+  const configBeta = parseConfig(YAML_BETA);
+
+  council = createApp({
+    dbPath: join(tmpDir, 'test.db'),
+    configs: [
+      { councilId: 'alpha-id', config: configAlpha },
+      { councilId: 'beta-id', config: configBeta },
+    ],
+    mcpBaseUrl: 'http://localhost:0/mcp',
+  });
+
+  await new Promise<void>((resolve) => {
+    council.httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const addr = council.httpServer.address();
+  if (typeof addr === 'object' && addr) {
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  }
+
+  // Bootstrap admin user
+  const setupRes = await fetch(`${baseUrl}/auth/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'admin@test.com', displayName: 'Admin', password: 'testpassword' }),
+  });
+  expect(setupRes.ok).toBe(true);
+  sessionCookie = setupRes.headers.getSetCookie()?.[0]?.split(';')[0] ?? '';
+});
+
+afterAll(async () => {
+  await council.close();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  return { Cookie: sessionCookie, 'Content-Type': 'application/json', ...extra };
+}
+
+describe('Multi-council app setup', () => {
+  it('creates app with multiple councils', () => {
+    expect(council.registry.size).toBe(2);
+    expect(council.councilId).toBe('alpha-id');
+    expect(council.orchestrator).toBeDefined();
+  });
+
+  it('lists both councils via API', async () => {
+    const res = await fetch(`${baseUrl}/api/councils`, { headers: authHeaders() });
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data).toHaveLength(2);
+    expect(data.map((c: any) => c.name).sort()).toEqual(['Alpha Council', 'Beta Council']);
+  });
+
+  it('default council is the first registered', () => {
+    expect(council.registry.getDefaultId()).toBe('alpha-id');
+  });
+});
+
+describe('Session isolation', () => {
+  it('creates sessions in specific councils via nested routes', async () => {
+    const resA = await fetch(`${baseUrl}/api/councils/alpha-id/sessions`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ title: 'Alpha Session' }),
+    });
+    expect(resA.status).toBe(201);
+    const sessionA = await resA.json();
+    expect(sessionA.councilId).toBe('alpha-id');
+
+    const resB = await fetch(`${baseUrl}/api/councils/beta-id/sessions`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ title: 'Beta Session' }),
+    });
+    expect(resB.status).toBe(201);
+    const sessionB = await resB.json();
+    expect(sessionB.councilId).toBe('beta-id');
+  });
+
+  it('flat sessions route uses default council', async () => {
+    const res = await fetch(`${baseUrl}/api/sessions`, { headers: authHeaders() });
+    expect(res.ok).toBe(true);
+    const sessions = await res.json();
+    // Should only show alpha sessions (default council)
+    for (const s of sessions) {
+      expect(s.councilId).toBe('alpha-id');
+    }
+  });
+
+  it('flat sessions route supports ?councilId filter', async () => {
+    const res = await fetch(`${baseUrl}/api/sessions?councilId=beta-id`, { headers: authHeaders() });
+    expect(res.ok).toBe(true);
+    const sessions = await res.json();
+    for (const s of sessions) {
+      expect(s.councilId).toBe('beta-id');
+    }
+  });
+
+  it('council-scoped sessions are isolated', async () => {
+    const resA = await fetch(`${baseUrl}/api/councils/alpha-id/sessions`, { headers: authHeaders() });
+    const sessionsA = await resA.json();
+
+    const resB = await fetch(`${baseUrl}/api/councils/beta-id/sessions`, { headers: authHeaders() });
+    const sessionsB = await resB.json();
+
+    // No overlap in session IDs
+    const idsA = new Set(sessionsA.map((s: any) => s.id));
+    const idsB = new Set(sessionsB.map((s: any) => s.id));
+    for (const id of idsA) {
+      expect(idsB.has(id)).toBe(false);
+    }
+  });
+});
+
+describe('Agent isolation', () => {
+  it('shows agents for specific council via nested route', async () => {
+    const resA = await fetch(`${baseUrl}/api/councils/alpha-id/agents`, { headers: authHeaders() });
+    expect(resA.ok).toBe(true);
+    const agentsA = await resA.json();
+    expect(agentsA).toHaveLength(1);
+    expect(agentsA[0].id).toBe('alpha-lead');
+
+    const resB = await fetch(`${baseUrl}/api/councils/beta-id/agents`, { headers: authHeaders() });
+    expect(resB.ok).toBe(true);
+    const agentsB = await resB.json();
+    expect(agentsB).toHaveLength(1);
+    expect(agentsB[0].id).toBe('beta-lead');
+  });
+
+  it('flat agents route uses default council', async () => {
+    const res = await fetch(`${baseUrl}/api/agents`, { headers: authHeaders() });
+    expect(res.ok).toBe(true);
+    const agents = await res.json();
+    expect(agents).toHaveLength(1);
+    expect(agents[0].id).toBe('alpha-lead');
+  });
+});
+
+describe('Webhook dispatch', () => {
+  it('routes generic event to correct council via ?councilId', async () => {
+    // Beta council has routing for beta.event
+    const res = await fetch(`${baseUrl}/webhooks/ingest?councilId=beta-id`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Event-Type': 'beta.event' },
+      body: JSON.stringify({ title: 'Beta webhook event' }),
+    });
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.status).toBe('session_created');
+    expect(data.councilId).toBe('beta-id');
+  });
+
+  it('broadcasts to all councils when no councilId specified', async () => {
+    const res = await fetch(`${baseUrl}/webhooks/ingest`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Event-Type': 'alpha.event' },
+      body: JSON.stringify({ title: 'Alpha broadcast event' }),
+    });
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.status).toBe('session_created');
+    expect(data.councilId).toBe('alpha-id');
+  });
+
+  it('returns 404 for unknown council in webhook', async () => {
+    const res = await fetch(`${baseUrl}/webhooks/ingest?councilId=nonexistent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Event-Type': 'test.event' },
+      body: JSON.stringify({ data: 'test' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('Council management', () => {
+  it('gets council details with agent statuses', async () => {
+    const res = await fetch(`${baseUrl}/api/councils/alpha-id`, { headers: authHeaders() });
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.name).toBe('Alpha Council');
+    expect(data.agents).toBeDefined();
+    expect(data.active).toBe(true);
+  });
+
+  it('returns 404 for unknown council', async () => {
+    const res = await fetch(`${baseUrl}/api/councils/nonexistent`, { headers: authHeaders() });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for scoped routes with unknown council', async () => {
+    const res = await fetch(`${baseUrl}/api/councils/nonexistent/sessions`, { headers: authHeaders() });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('Event isolation', () => {
+  it('shows events scoped to council', async () => {
+    const resA = await fetch(`${baseUrl}/api/councils/alpha-id/events`, { headers: authHeaders() });
+    expect(resA.ok).toBe(true);
+    const eventsA = await resA.json();
+
+    const resB = await fetch(`${baseUrl}/api/councils/beta-id/events`, { headers: authHeaders() });
+    expect(resB.ok).toBe(true);
+    const eventsB = await resB.json();
+
+    // Events should be council-scoped (no cross-contamination)
+    for (const e of eventsA) {
+      expect(e.councilId).toBe('alpha-id');
+    }
+    for (const e of eventsB) {
+      expect(e.councilId).toBe('beta-id');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `OrchestratorRegistry` engine class that maps councilId → Orchestrator + full engine stack (AgentRegistry, EventRouter, config)
- Refactors `createApp()` to accept `configs[]` for multiple councils while maintaining backward compatibility with single `config` option
- Threads the registry through all server consumers: API routes, webhooks, WebSocket, MCP agent/user endpoints, and admin API
- Adds council-scoped API routes (`/api/councils/:councilId/sessions`, etc.) alongside backward-compatible flat routes with `?councilId=` query param
- Migrates `agent_tokens` table to composite PK `(agent_id, council_id)` to support same agent ID across councils
- Adds `CouncilSelector` dropdown and `CouncilManagement` view to the web UI
- Supports `MULTI_CONFIG_DIR` env var for loading multiple YAML configs from a directory
- WsEvent types gain optional `councilId` field for client-side filtering

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — all 293 tests pass (265 existing + 28 new)
- [x] `pnpm build` — server + web build succeeds
- [ ] Manual: Start with `MULTI_CONFIG_DIR=config/examples pnpm dev` and verify council selector appears
- [ ] Manual: Create sessions in different councils, verify isolation
- [ ] Manual: Webhook dispatch routes to correct council
- [ ] Manual: Create new council via UI YAML textarea
- [ ] Manual: Agent tokens scoped per council — no cross-council leakage

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)